### PR TITLE
Improving scaling / unit conversion

### DIFF
--- a/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
@@ -4,10 +4,22 @@ import com.gu.recipe.generated.*
 import com.gu.recipe.template.ParsedTemplate
 import com.gu.recipe.template.TemplateElement
 import com.gu.recipe.template.parseTemplate
+import kotlin.math.round
 
 sealed interface IngredientUnit {
     object Imperial : IngredientUnit
     object Metric : IngredientUnit
+}
+
+private fun formatNumber(number: Float, decimals: Int): String {
+    var multiplier = 1.0
+    repeat(decimals) { multiplier *= 10 }
+    val roundedNumber = round(number * multiplier) / multiplier
+    // If the number is an integer, don't show decimal places
+    if (roundedNumber % 1.0 == 0.0) {
+        return roundedNumber.toInt().toString()
+    }
+    return roundedNumber.toString()
 }
 
 private fun scaleTemplate(template: ParsedTemplate, factor: Float): String {
@@ -22,12 +34,17 @@ private fun scaleTemplate(template: ParsedTemplate, factor: Float): String {
                 } else {
                     Pair(element.min, element.max)
                 }
-                val unit = element.unit ?: ""
-                // TODO, we'll probably need to decide if we want to round the values depending on the unit
+                val unit = if (element.unit != null) " ${element.unit}" else ""
+
+                val decimals = when(unit) {
+                    "g", "ml" -> 0
+                    else -> 2
+                }
+
                 if (scaledMax != null) {
-                    "${scaledMin.toInt()}-${scaledMax.toInt()} $unit"
+                    "${formatNumber(scaledMin, decimals)}-${formatNumber(scaledMax, decimals)}$unit"
                 } else {
-                    "${scaledMin.toInt()} $unit"
+                    "${formatNumber(scaledMin, decimals)}$unit"
                 }
             }
 

--- a/library/src/commonTest/kotlin/com/gu/recipe/FormatNumberTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/FormatNumberTest.kt
@@ -6,43 +6,43 @@ import kotlin.test.assertEquals
 class FormatNumberTest {
     @Test
     fun `integer value no decimals`() {
-        assertEquals("5", formatNumber(5f, 2, false))
-        assertEquals("0", formatNumber(0f, 2, false))
+        assertEquals("5", formatAmount(5f, 2, false))
+        assertEquals("0", formatAmount(0f, 2, false))
     }
 
     @Test
     fun `decimal value rounded correctly`() {
-        assertEquals("2.5", formatNumber(2.5f, 1, false))
-        assertEquals("2.56", formatNumber(2.555f, 2, false))
-        assertEquals("2.56", formatNumber(2.555f, 2, true))
+        assertEquals("2.5", formatAmount(2.5f, 1, false))
+        assertEquals("2.56", formatAmount(2.555f, 2, false))
+        assertEquals("2.56", formatAmount(2.555f, 2, true))
     }
 
     @Test
     fun `fractional value unicode fractions`() {
-        assertEquals("½", formatNumber(0.5f, 2, true))
-        assertEquals("¼", formatNumber(0.25f, 2, true))
-        assertEquals("¾", formatNumber(0.75f, 2, true))
-        assertEquals("1½", formatNumber(1.5f, 2, true))
-        assertEquals("2¼", formatNumber(2.25f, 2, true))
+        assertEquals("½", formatAmount(0.5f, 2, true))
+        assertEquals("¼", formatAmount(0.25f, 2, true))
+        assertEquals("¾", formatAmount(0.75f, 2, true))
+        assertEquals("1½", formatAmount(1.5f, 2, true))
+        assertEquals("2¼", formatAmount(2.25f, 2, true))
     }
 
     @Test
     fun `fraction parameter false returns decimals`() {
-        assertEquals("0.5", formatNumber(0.5f, 2, false))
-        assertEquals("2.25", formatNumber(2.25f, 2, false))
+        assertEquals("0.5", formatAmount(0.5f, 2, false))
+        assertEquals("2.25", formatAmount(2.25f, 2, false))
     }
 
     @Test
     fun `decimals parameter effect`() {
-        assertEquals("2", formatNumber(2f, 0, false))
-        assertEquals("2.6", formatNumber(2.555f, 1, false))
-        assertEquals("2.56", formatNumber(2.555f, 2, false))
+        assertEquals("2", formatAmount(2f, 0, false))
+        assertEquals("2.6", formatAmount(2.555f, 1, false))
+        assertEquals("2.56", formatAmount(2.555f, 2, false))
     }
 
     @Test
     fun `edge cases`() {
-        assertEquals("0", formatNumber(0f, 2, true))
-        assertEquals("0", formatNumber(0f, 2, false))
+        assertEquals("0", formatAmount(0f, 2, true))
+        assertEquals("0", formatAmount(0f, 2, false))
     }
 }
 

--- a/library/src/commonTest/kotlin/com/gu/recipe/FormatNumberTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/FormatNumberTest.kt
@@ -1,0 +1,48 @@
+package com.gu.recipe
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class FormatNumberTest {
+    @Test
+    fun `integer value no decimals`() {
+        assertEquals("5", formatNumber(5f, 2, false))
+        assertEquals("0", formatNumber(0f, 2, false))
+    }
+
+    @Test
+    fun `decimal value rounded correctly`() {
+        assertEquals("2.5", formatNumber(2.5f, 1, false))
+        assertEquals("2.56", formatNumber(2.555f, 2, false))
+        assertEquals("2.56", formatNumber(2.555f, 2, true))
+    }
+
+    @Test
+    fun `fractional value unicode fractions`() {
+        assertEquals("½", formatNumber(0.5f, 2, true))
+        assertEquals("¼", formatNumber(0.25f, 2, true))
+        assertEquals("¾", formatNumber(0.75f, 2, true))
+        assertEquals("1½", formatNumber(1.5f, 2, true))
+        assertEquals("2¼", formatNumber(2.25f, 2, true))
+    }
+
+    @Test
+    fun `fraction parameter false returns decimals`() {
+        assertEquals("0.5", formatNumber(0.5f, 2, false))
+        assertEquals("2.25", formatNumber(2.25f, 2, false))
+    }
+
+    @Test
+    fun `decimals parameter effect`() {
+        assertEquals("2", formatNumber(2f, 0, false))
+        assertEquals("2.6", formatNumber(2.555f, 1, false))
+        assertEquals("2.56", formatNumber(2.555f, 2, false))
+    }
+
+    @Test
+    fun `edge cases`() {
+        assertEquals("0", formatNumber(0f, 2, true))
+        assertEquals("0", formatNumber(0f, 2, false))
+    }
+}
+

--- a/library/src/commonTest/kotlin/com/gu/recipe/ScaleRecipeTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/ScaleRecipeTest.kt
@@ -51,7 +51,7 @@ class ScaleRecipeTest {
                     )
                 )
             ),
-            instructions = listOf(InstructionElement(description = "pre-warm the oven to 180°C (160°C fan)"))
+            instructions = listOf(InstructionElement(description = "pre-warm the oven to 180C (160C fan)"))
         )
         val scaledRecipe = scaleRecipe(recipeTemplate, 2.0f, unit = IngredientUnit.Metric)
         assertEquals(

--- a/library/src/commonTest/kotlin/com/gu/recipe/ScaleRecipeTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/ScaleRecipeTest.kt
@@ -18,6 +18,9 @@ class ScaleRecipeTest {
                     ingredientsList = listOf(
                         IngredientsTemplateIngredientsList(
                             template = """{"min": 100, "max": 120, "unit": "g", "scale": true} of flour"""
+                        ),
+                        IngredientsTemplateIngredientsList(
+                            template = """{"min": 1.2, "unit": "kg", "scale": true} of potatoes"""
                         )
                     )
                 )
@@ -35,6 +38,9 @@ class ScaleRecipeTest {
                     ingredientsList = listOf(
                         IngredientsListIngredientsList(
                             text = "200-240 g of flour"
+                        ),
+                        IngredientsListIngredientsList(
+                            text = "2.4 kg of potatoes"
                         )
                     )
                 )

--- a/library/src/commonTest/kotlin/com/gu/recipe/ScaleRecipeTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/ScaleRecipeTest.kt
@@ -21,6 +21,9 @@ class ScaleRecipeTest {
                         ),
                         IngredientsTemplateIngredientsList(
                             template = """{"min": 1.2, "unit": "kg", "scale": true} of potatoes"""
+                        ),
+                        IngredientsTemplateIngredientsList(
+                            template = """{"min": 0.25, "unit": "tbsp", "scale": true} of salt"""
                         )
                     )
                 )
@@ -41,6 +44,9 @@ class ScaleRecipeTest {
                         ),
                         IngredientsListIngredientsList(
                             text = "2.4 kg of potatoes"
+                        ),
+                        IngredientsListIngredientsList(
+                            text = "½ tbsp of salt"
                         )
                     )
                 )

--- a/library/src/commonTest/kotlin/com/gu/recipe/ScaleTemplateTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/ScaleTemplateTest.kt
@@ -137,7 +137,7 @@ class ScaleTemplateTest {
             )
         )
         val result = scaleTemplate(template, 2f)
-        assertEquals("180°C (160°C fan)", result)
+        assertEquals("180C (160C fan)", result)
     }
 
     @Test
@@ -150,7 +150,7 @@ class ScaleTemplateTest {
             )
         )
         val result = scaleTemplate(template, 2f)
-        assertEquals("200°C", result)
+        assertEquals("200C", result)
     }
 
     @Test
@@ -202,7 +202,7 @@ class ScaleTemplateTest {
             )
         )
         val result = scaleTemplate(template, 2f)
-        assertEquals("Bake at 180°C (160°C fan) for 30-40 minutes.", result)
+        assertEquals("Bake at 180C (160C fan) for 30-40 minutes.", result)
     }
 
     @Test

--- a/library/src/commonTest/kotlin/com/gu/recipe/ScaleTemplateTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/ScaleTemplateTest.kt
@@ -1,0 +1,283 @@
+package com.gu.recipe
+
+import com.gu.recipe.template.ParsedTemplate
+import com.gu.recipe.template.TemplateElement
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ScaleTemplateTest {
+    @Test
+    fun `scale template with simple quantity placeholder`() {
+        val template = ParsedTemplate(
+            listOf(
+                TemplateElement.QuantityPlaceholder(
+                    min = 100f,
+                    unit = "g",
+                    scale = true
+                )
+            )
+        )
+        val result = scaleTemplate(template, 2f)
+        assertEquals("200 g", result)
+    }
+
+    @Test
+    fun `scale template with quantity range`() {
+        val template = ParsedTemplate(
+            listOf(
+                TemplateElement.QuantityPlaceholder(
+                    min = 100f,
+                    max = 150f,
+                    unit = "g",
+                    scale = true
+                )
+            )
+        )
+        val result = scaleTemplate(template, 2f)
+        assertEquals("200-300 g", result)
+    }
+
+    @Test
+    fun `scale template with fraction for tbsp`() {
+        val template = ParsedTemplate(
+            listOf(
+                TemplateElement.QuantityPlaceholder(
+                    min = 0.5f,
+                    unit = "tbsp",
+                    scale = true
+                )
+            )
+        )
+        val result = scaleTemplate(template, 2f)
+        assertEquals("1 tbsp", result)
+    }
+
+    @Test
+    fun `scale template with fraction for tsp`() {
+        val template = ParsedTemplate(
+            listOf(
+                TemplateElement.QuantityPlaceholder(
+                    min = 0.25f,
+                    unit = "tsp",
+                    scale = true
+                )
+            )
+        )
+        val result = scaleTemplate(template, 2f)
+        assertEquals("½ tsp", result)
+    }
+
+    @Test
+    fun `scale template with fraction for cups`() {
+        val template = ParsedTemplate(
+            listOf(
+                TemplateElement.QuantityPlaceholder(
+                    min = 1.5f,
+                    unit = "cups",
+                    scale = true
+                )
+            )
+        )
+        val result = scaleTemplate(template, 0.5f)
+        assertEquals("¾ cups", result)
+    }
+
+    @Test
+    fun `scale template without unit uses fractions`() {
+        val template = ParsedTemplate(
+            listOf(
+                TemplateElement.QuantityPlaceholder(
+                    min = 2f,
+                    scale = true
+                )
+            )
+        )
+        val result = scaleTemplate(template, 0.5f)
+        assertEquals("1", result)
+    }
+
+    @Test
+    fun `scale template with ml uses no decimals`() {
+        val template = ParsedTemplate(
+            listOf(
+                TemplateElement.QuantityPlaceholder(
+                    min = 250f,
+                    unit = "ml",
+                    scale = true
+                )
+            )
+        )
+        val result = scaleTemplate(template, 1.5f)
+        assertEquals("375 ml", result)
+    }
+
+    @Test
+    fun `scale template with non-scalable quantity`() {
+        val template = ParsedTemplate(
+            listOf(
+                TemplateElement.QuantityPlaceholder(
+                    min = 100f,
+                    unit = "g",
+                    scale = false
+                )
+            )
+        )
+        val result = scaleTemplate(template, 2f)
+        assertEquals("100 g", result)
+    }
+
+    @Test
+    fun `scale template with oven temperature`() {
+        val template = ParsedTemplate(
+            listOf(
+                TemplateElement.OvenTemperaturePlaceholder(
+                    temperatureC = 180,
+                    temperatureFanC = 160
+                )
+            )
+        )
+        val result = scaleTemplate(template, 2f)
+        assertEquals("180°C (160°C fan)", result)
+    }
+
+    @Test
+    fun `scale template with oven temperature without fan`() {
+        val template = ParsedTemplate(
+            listOf(
+                TemplateElement.OvenTemperaturePlaceholder(
+                    temperatureC = 200
+                )
+            )
+        )
+        val result = scaleTemplate(template, 2f)
+        assertEquals("200°C", result)
+    }
+
+    @Test
+    fun `scale template with const text`() {
+        val template = ParsedTemplate(
+            listOf(
+                TemplateElement.TemplateConst("Add ")
+            )
+        )
+        val result = scaleTemplate(template, 2f)
+        assertEquals("Add ", result)
+    }
+
+    @Test
+    fun `scale template with mixed elements`() {
+        val template = ParsedTemplate(
+            listOf(
+                TemplateElement.TemplateConst("Add "),
+                TemplateElement.QuantityPlaceholder(
+                    min = 100f,
+                    max = 120f,
+                    unit = "g",
+                    scale = true
+                ),
+                TemplateElement.TemplateConst(" of flour")
+            )
+        )
+        val result = scaleTemplate(template, 2f)
+        assertEquals("Add 200-240 g of flour", result)
+    }
+
+    @Test
+    fun `scale template with complex recipe instruction`() {
+        val template = ParsedTemplate(
+            listOf(
+                TemplateElement.TemplateConst("Bake at "),
+                TemplateElement.OvenTemperaturePlaceholder(
+                    temperatureC = 180,
+                    temperatureFanC = 160
+                ),
+                TemplateElement.TemplateConst(" for "),
+                TemplateElement.QuantityPlaceholder(
+                    min = 30f,
+                    max = 40f,
+                    unit = "minutes",
+                    scale = false
+                ),
+                TemplateElement.TemplateConst(".")
+            )
+        )
+        val result = scaleTemplate(template, 2f)
+        assertEquals("Bake at 180°C (160°C fan) for 30-40 minutes.", result)
+    }
+
+    @Test
+    fun `scale template with factor less than 1`() {
+        val template = ParsedTemplate(
+            listOf(
+                TemplateElement.QuantityPlaceholder(
+                    min = 200f,
+                    unit = "g",
+                    scale = true
+                )
+            )
+        )
+        val result = scaleTemplate(template, 0.5f)
+        assertEquals("100 g", result)
+    }
+
+    @Test
+    fun `scale template with non-standard unit uses decimals`() {
+        val template = ParsedTemplate(
+            listOf(
+                TemplateElement.QuantityPlaceholder(
+                    min = 1f,
+                    unit = "kg",
+                    scale = true
+                )
+            )
+        )
+        val result = scaleTemplate(template, 1.5f)
+        assertEquals("1.5 kg", result)
+    }
+
+    @Test
+    fun `scale template with quantity without unit showing fraction`() {
+        val template = ParsedTemplate(
+            listOf(
+                TemplateElement.QuantityPlaceholder(
+                    min = 1f,
+                    scale = true
+                )
+            )
+        )
+        val result = scaleTemplate(template, 0.75f)
+        assertEquals("¾", result)
+    }
+
+    @Test
+    fun `scale template with range and fractions`() {
+        val template = ParsedTemplate(
+            listOf(
+                TemplateElement.QuantityPlaceholder(
+                    min = 0.5f,
+                    max = 1f,
+                    unit = "tsp",
+                    scale = true
+                )
+            )
+        )
+        val result = scaleTemplate(template, 2f)
+        assertEquals("1-2 tsp", result)
+    }
+
+    @Test
+    fun `scale template preserves integer values without decimals`() {
+        val template = ParsedTemplate(
+            listOf(
+                TemplateElement.QuantityPlaceholder(
+                    min = 2f,
+                    unit = "kg",
+                    scale = true
+                )
+            )
+        )
+        val result = scaleTemplate(template, 2f)
+        assertEquals("4 kg", result)
+    }
+}
+


### PR DESCRIPTION
This PR improves the formatting of the recipes into something more consistent with our own recipes.

It touches:
- General number formatting to avoid using decimal number when there are integers
- Limit the number of decimal digit in the case of a float
- Handle fractions
- Format our oven temperature more consistently

This is far from the last PR on these subjects, but it should start giving us something very close to our original recipes.