### PR TITLE
Less strict json parsing

### DIFF
--- a/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
@@ -15,6 +15,7 @@ internal fun formatFraction(number: Float): String {
     val integerPart = number.toInt()
     val fractionalPart = number - integerPart
     val fractionString = when (fractionalPart) {
+        in 0.12f..0.13f -> "⅛"
         0.25f -> "¼"
         0.5f -> "½"
         0.75f -> "¾"

--- a/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
@@ -53,7 +53,10 @@ internal fun scaleTemplate(template: ParsedTemplate, factor: Float): String {
             is TemplateElement.QuantityPlaceholder -> {
                 val (scaledMin, scaledMax) = if (element.scale) {
                     val scaledMin = (element.min * factor)
-                    val scaledMax = element.max?.let { (it * factor) }
+                    val scaledMax = if (element.min != element.max) {
+                        element.max?.let { (it * factor) }
+                    } else null
+
                     Pair(scaledMin, scaledMax)
                 } else {
                     Pair(element.min, element.max)

--- a/library/src/commonMain/kotlin/com/gu/recipe/template/Parser.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/template/Parser.kt
@@ -5,6 +5,8 @@ import com.gu.recipe.generated.StringTemplate
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
 
+private val tolerantJson = Json { ignoreUnknownKeys = true }
+
 fun parseTemplate(template: StringTemplate): ParsedTemplate {
     val pattern = Regex("""\{(?:[^{}"]|"(?:[^"\\\\]|\\\\.)*")*\}""")
     val parts = mutableListOf<TemplateElement>()
@@ -23,11 +25,11 @@ fun parseTemplate(template: StringTemplate): ParsedTemplate {
         try {
             val jsonObj = Json.parseToJsonElement(match.value).jsonObject
             if (jsonObj.keys.contains("min")) {
-                Json.decodeFromJsonElement<TemplateElement.QuantityPlaceholder>(jsonObj).let {
+                tolerantJson.decodeFromJsonElement<TemplateElement.QuantityPlaceholder>(jsonObj).let {
                     parts.add(it)
                 }
             } else {
-                Json.decodeFromJsonElement<TemplateElement.OvenTemperaturePlaceholder>(jsonObj).let {
+                tolerantJson.decodeFromJsonElement<TemplateElement.OvenTemperaturePlaceholder>(jsonObj).let {
                     parts.add(it)
                 }
             }

--- a/library/src/commonTest/kotlin/com/gu/recipe/ScaleTemplateTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/ScaleTemplateTest.kt
@@ -279,5 +279,21 @@ class ScaleTemplateTest {
         val result = scaleTemplate(template, 2f)
         assertEquals("4 kg", result)
     }
+
+    @Test
+    fun `scale template should ignore max value if identical to min`() {
+        val template = ParsedTemplate(
+            listOf(
+                TemplateElement.QuantityPlaceholder(
+                    min = 2f,
+                    max = 2f,
+                    unit = "kg",
+                    scale = true
+                )
+            )
+        )
+        val result = scaleTemplate(template, 2f)
+        assertEquals("4 kg", result)
+    }
 }
 

--- a/library/src/commonTest/kotlin/com/gu/recipe/template/TemplateParserTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/template/TemplateParserTest.kt
@@ -25,4 +25,24 @@ class TemplateParserTest {
             parsed.elements
         )
     }
+    @Test
+    fun `parse a template - ignoring extra properties`() {
+        val template: StringTemplate =
+            "Bake at {\"temperatureC\": 180, \"temperatureFanC\": 160, \"newProperty\": true} for {\"min\": 30, \"max\": 40, \"unit\": \"minutes\", \"newProperty\": true}."
+        val parsed = parseTemplate(template)
+
+        assertEquals(
+            listOf(
+                TemplateElement.TemplateConst("Bake at "),
+                TemplateElement.OvenTemperaturePlaceholder(
+                    temperatureC = 180,
+                    temperatureFanC = 160
+                ),
+                TemplateElement.TemplateConst(" for "),
+                TemplateElement.QuantityPlaceholder(min = 30f, max = 40f, unit = "minutes"),
+                TemplateElement.TemplateConst(".")
+            ),
+            parsed.elements
+        )
+    }
 }


### PR DESCRIPTION
Fix three things:
- tolerate that a string template can contain unexpected fields, this allows us to make the data evolve without having to worry about a client side crash
- If a template has a min and max value, but they're equal, we ignore the max value. This is because sometimes we'd get ingredients formatted as follows: '2-2 garlic cloves'
- handles 1/8 fractions