### PR TITLE
Add comment body to scaleRecipe and change function name

### DIFF
--- a/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
@@ -65,7 +65,7 @@ internal fun scaleTemplate(template: ParsedTemplate, factor: Float): String {
                 }
                 val unit = if (element.unit != null) " ${element.unit}" else ""
 
-                val decimals = when(unit) {
+                val decimals = when (unit) {
                     "g", "ml" -> 0
                     else -> 2
                 }
@@ -84,7 +84,7 @@ internal fun scaleTemplate(template: ParsedTemplate, factor: Float): String {
             }
 
             is TemplateElement.OvenTemperaturePlaceholder -> {
-                val fanTempC = element.temperatureFanC?. let {
+                val fanTempC = element.temperatureFanC?.let {
                     if (element.temperatureC == null) {
                         "${element.temperatureFanC}C fan"
                     } else {
@@ -107,7 +107,16 @@ internal fun scaleTemplate(template: ParsedTemplate, factor: Float): String {
 typealias ClientSideRecipe = RecipeV2
 typealias ServerSideRecipe = RecipeV3
 
-fun scaleRecipe(recipe: ServerSideRecipe, factor: Float, unit: IngredientUnit): ClientSideRecipe {
+/**
+ * scaleAndConvertUnitRecipe used to convert units and scale recipe
+ *
+ * @param recipe The recipe as provided by the server (RecipeV3)
+ * @param factor
+ *  The factor applied to change the proportions of the recipe. For instance 0.5 halves the recipe and 2 doubles it.
+ *  To calculate the factor, take the number of desired servings and divide it by the original servings.
+ * @param unit unit to which you want to change
+*/
+fun scaleAndConvertUnitRecipe(recipe: ServerSideRecipe, factor: Float, unit: IngredientUnit): ClientSideRecipe {
     val scaledIngredients = recipe.ingredientsTemplate?.map { ingredientSection ->
         IngredientElement(
             ingredientsList = ingredientSection.ingredientsList?.map { templateIngredient ->

--- a/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
@@ -111,10 +111,10 @@ typealias ServerSideRecipe = RecipeV3
  * scaleAndConvertUnitRecipe used to convert units and scale recipe
  *
  * @param recipe The recipe as provided by the server (RecipeV3)
- * @param factor
- *  The factor applied to change the proportions of the recipe. For instance 0.5 halves the recipe and 2 doubles it.
+ * @param factor The factor applied to change the proportions of the recipe.
+ *  For instance 0.5 halves the recipe and 2 doubles it.
  *  To calculate the factor, take the number of desired servings and divide it by the original servings.
- * @param unit unit to which you want to change
+ * @param unit The target unit system for ingredient measurements (e.g., Metric or Imperial)
 */
 fun scaleAndConvertUnitRecipe(recipe: ServerSideRecipe, factor: Float, unit: IngredientUnit): ClientSideRecipe {
     val scaledIngredients = recipe.ingredientsTemplate?.map { ingredientSection ->

--- a/library/src/commonTest/kotlin/com/gu/recipe/ScaleRecipeTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/ScaleRecipeTest.kt
@@ -4,7 +4,7 @@ import com.gu.recipe.ClientSideRecipe
 import com.gu.recipe.IngredientUnit
 import com.gu.recipe.ServerSideRecipe
 import com.gu.recipe.generated.*
-import com.gu.recipe.scaleRecipe
+import com.gu.recipe.scaleAndConvertUnitRecipe
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -65,7 +65,7 @@ class ScaleRecipeTest {
                 InstructionElement(description = "pre-warm the oven to 160C fan/325F"),
             )
         )
-        val scaledRecipe = scaleRecipe(recipeTemplate, 2.0f, unit = IngredientUnit.Metric)
+        val scaledRecipe = scaleAndConvertUnitRecipe(recipeTemplate, 2.0f, unit = IngredientUnit.Metric)
         assertEquals(
             expectedRecipe,
             scaledRecipe

--- a/library/src/jsMain/kotlin/com/gu/recipe/js/ScaleRecipeJsContract.kt
+++ b/library/src/jsMain/kotlin/com/gu/recipe/js/ScaleRecipeJsContract.kt
@@ -15,6 +15,6 @@ fun scaleRecipe(recipe: String, factor: Float, unit: String): String {
         "Metric" -> IngredientUnit.Metric
         else -> throw IllegalArgumentException("Unknown unit: $unit")
     }
-    val scaledRecipe = com.gu.recipe.scaleRecipe(parsedRecipe, factor, ingredientUnit)
+    val scaledRecipe = com.gu.recipe.scaleAndConvertUnitRecipe(parsedRecipe, factor, ingredientUnit)
     return Json.encodeToString(scaledRecipe)
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR renames the `scaleRecipe` function to `scaleAndConvertUnitRecipe` to better reflect its dual purpose of scaling recipes and converting units. Additionally, it adds comprehensive documentation explaining the function's parameters and providing guidance on calculating the scaling factor.

- Renamed `scaleRecipe` to `scaleAndConvertUnitRecipe` for improved clarity
- Added KDoc documentation with parameter descriptions and factor calculation guidance
- Updated all references to use the new function name

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
