### PR TITLE
NPM Token & Branch Protection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,7 +112,9 @@ jobs:
   publish-npm:
     needs: release
     runs-on: ubuntu-22.04
-    permissions: { contents: read }
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -141,8 +143,6 @@ jobs:
         run: ./gradlew :library:compileProductionExecutableKotlinJs
 
       - name: Publish to npm
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           cd build/js/packages/feast-multiplatform-library-library
           npm publish --access public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,20 @@ jobs:
       - name: Build and zip XCFramework
         run: ./gradlew :library:publishXCFrameworkToGitHub
 
+      - uses: actions/create-github-app-token@v2
+        id: create-app-token
+        with:
+          app-id: ${{ secrets.GU_SWIFT_LIBRARY_RELEASE_CLIENT_ID }}
+          private-key: ${{ secrets.GU_SWIFT_LIBRARY_RELEASE_PRIVATE_KEY }}
+          owner: guardian
+          permission-contents: write
+
+      - name: Get GitHub User ID
+        id: get-user-id
+        run: echo "user-id=$(gh api "/users/${{ steps.create-app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.create-app-token.outputs.token }}
+
       - name: Upload XCFramework artifact
         uses: actions/upload-artifact@v4
         with:
@@ -55,8 +69,8 @@ jobs:
 
       - name: Commit and push Package.swift changes
         run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
+          git config --local user.email "${{ steps.get-user-id.outputs.user-id }}+${{ steps.create-app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
+          git config --local user.name "${{ steps.app-token.outputs.app-slug }}[bot]"
           git add Package.swift
           git commit -m "Update Package.swift for release ${{ steps.version.outputs.VERSION }}"
           git push

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -61,6 +61,7 @@ kotlin {
             customField("description", Config.PACKAGE_DESCRIPTION)
             customField("keywords", listOf("kotlin", "multiplatform"))
             customField("license", "Apache-2.0")
+            customField("repository", mapOf("url" to "https://github.com/guardian/feast-multiplatform-library"))
         }
     }
 


### PR DESCRIPTION
In this PR I address two aspects that aren't up to date with our latest DevX best practices:

- We shouldn't be using the github "action" user to push to main, we should be using the token generated by an app that's been specifically allowed to push to our main branch
- We shouldn't be using the NPM token anymore, as we're using the [trusted publisher](https://docs.npmjs.com/trusted-publishers#step-1-add-a-trusted-publisher-on-npmjscom) approach now