### PR TITLE
Replace simple punctuation with nicer one

### DIFF
--- a/library/src/commonMain/kotlin/com/gu/recipe/FormatUtils.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/FormatUtils.kt
@@ -40,4 +40,15 @@ internal object FormatUtils {
         }
         return roundedNumber.toString()
     }
+
+    val captureMatchingQuotes = Regex("([\"])(.*?)([\"])")
+
+    fun applySmartPunctuation(text: String): String {
+        // capture opening quotes with their matching closing quote in order to replace each pair together with opening and closing fancy quotes
+        val withQuotes = captureMatchingQuotes.replace(text) { matchResult ->
+            "“${matchResult.groupValues[2]}”"
+        }
+
+        return withQuotes.replace("'", "’")
+    }
 }

--- a/library/src/commonMain/kotlin/com/gu/recipe/FormatUtils.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/FormatUtils.kt
@@ -49,6 +49,8 @@ internal object FormatUtils {
             "“${matchResult.groupValues[2]}”"
         }
 
-        return withQuotes.replace("'", "’")
+        return withQuotes
+            .replace("'", "’")
+            .replace(" - ", " – ")
     }
 }

--- a/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
@@ -1,5 +1,6 @@
 package com.gu.recipe
 
+import com.gu.recipe.FormatUtils.applySmartPunctuation
 import com.gu.recipe.generated.*
 import com.gu.recipe.template.OvenTemperaturePlaceholder
 import com.gu.recipe.template.ParsedTemplate
@@ -89,7 +90,7 @@ internal fun renderTemplate(template: ParsedTemplate, factor: Float, measuringSy
         renderTemplateElement(element, factor, measuringSystem)
     }
 
-    return renderedParts.joinToString("")
+    return applySmartPunctuation(renderedParts.joinToString(""))
 }
 
 internal fun wrapWithStrongTag(value: String): String {

--- a/library/src/commonTest/kotlin/com/gu/recipe/FormatUtilsTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/FormatUtilsTest.kt
@@ -1,5 +1,6 @@
 package com.gu.recipe
 
+import com.gu.recipe.FormatUtils.applySmartPunctuation
 import com.gu.recipe.FormatUtils.formatAmount
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -45,5 +46,12 @@ class FormatUtilsTest {
         assertEquals("0", formatAmount(0f, 2, true))
         assertEquals("0", formatAmount(0f, 2, false))
     }
-}
 
+    @Test
+    fun `applySmartPunctuation replaces quotes and apostrophes`() {
+        assertEquals("“Hello”", applySmartPunctuation("\"Hello\""))
+        assertEquals("It’s", applySmartPunctuation("It's"))
+        assertEquals("“It’s”", applySmartPunctuation("\"It's\""))
+        assertEquals("Hello", applySmartPunctuation("Hello"))
+    }
+}

--- a/library/src/commonTest/kotlin/com/gu/recipe/RenderTemplateTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/RenderTemplateTest.kt
@@ -358,11 +358,11 @@ class RenderTemplateTest {
     fun `replace simple punctuation with Guardian style punctuation`() {
         val template = ParsedTemplate(
             listOf(
-                TemplateConst("Use \"00\" flour and you'll get the best results."),
+                TemplateConst("Use \"00\" flour and you'll get - I think - the best results."),
             )
         )
         val result = renderTemplate(template, 1f, MeasuringSystem.Metric)
-        assertEquals("Use “00” flour and you’ll get the best results.", result)
+        assertEquals("Use “00” flour and you’ll get – I think – the best results.", result)
     }
 }
 

--- a/library/src/commonTest/kotlin/com/gu/recipe/RenderTemplateTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/RenderTemplateTest.kt
@@ -353,5 +353,16 @@ class RenderTemplateTest {
         val result = renderTemplate(template, 1f, MeasuringSystem.Imperial)
         assertEquals("3.31 lbs 3.53 oz 1", result)
     }
+
+    @Test
+    fun `replace simple punctuation with Guardian style punctuation`() {
+        val template = ParsedTemplate(
+            listOf(
+                TemplateConst("Use \"00\" flour and you'll get the best results."),
+            )
+        )
+        val result = renderTemplate(template, 1f, MeasuringSystem.Metric)
+        assertEquals("Use “00” flour and you’ll get the best results.", result)
+    }
 }
 


### PR DESCRIPTION
## What does this change?

A pretty simple PR to match double quotes `"` and replace them with opening and closing quotes `“”`, as well as replace single quotes `'` with an apostrophe `’`

