### PR TITLE
A helper method for ingredient

### DIFF
--- a/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
@@ -95,16 +95,9 @@ internal fun renderTemplate(template: ParsedTemplate, factor: Float, measuringSy
 }
 
 internal fun wrapWithStrongTag(value: String): String {
-    val separators = charArrayOf(',', ';', '(')
-    val index = value.indexOfAny(separators)
-
-    if (index != -1) {
-        val before = value.substring(0, index)
-        val after = value.substring(index)
-        return """<strong>$before</strong>$after"""
-    } else {
-        return """<strong>$value</strong>"""
-    }
+    val before = ingredientWithoutSuffix(value)
+    val after = value.substring(before.length)
+    return """<strong>$before</strong>$after"""
 }
 
 /**
@@ -139,6 +132,6 @@ fun scaleAndConvertUnitRecipe(recipe: RecipeV3, factor: Float, measuringSystem: 
     return recipe.copy(ingredients = scaledIngredients, instructions = scaledInstructions)
 }
 
-fun textWithoutSuffix(text: String?): String? {
-    return text?.substringBefore(",")
+fun ingredientWithoutSuffix(renderedTemplate: String): String {
+    return renderedTemplate.substringBefore(",")
 }

--- a/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
@@ -138,3 +138,7 @@ fun scaleAndConvertUnitRecipe(recipe: RecipeV3, factor: Float, measuringSystem: 
 
     return recipe.copy(ingredients = scaledIngredients, instructions = scaledInstructions)
 }
+
+fun textWithoutSuffix(text: String?): String? {
+    return text?.substringBefore(",")
+}

--- a/library/src/commonMain/kotlin/com/gu/recipe/generated/RecipeModels.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/generated/RecipeModels.kt
@@ -256,7 +256,11 @@ data class IngredientItem (
      * Unit of measurement for the ingredient
      */
     val unit: String? = null
-)
+) {
+    fun textWithoutSuffix(): String? {
+        return text?.substringBefore(",")
+    }
+}
 
 /**
  * A numeric range with minimum and maximum values

--- a/library/src/commonMain/kotlin/com/gu/recipe/generated/RecipeModels.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/generated/RecipeModels.kt
@@ -256,11 +256,7 @@ data class IngredientItem (
      * Unit of measurement for the ingredient
      */
     val unit: String? = null
-) {
-    fun textWithoutSuffix(): String? {
-        return text?.substringBefore(",")
-    }
-}
+)
 
 /**
  * A numeric range with minimum and maximum values

--- a/library/src/commonTest/kotlin/com/gu/recipe/ScaleRecipeTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/ScaleRecipeTest.kt
@@ -3,6 +3,7 @@ package io.github.kotlin.fibonacci.com.gu.recipe
 import com.gu.recipe.unit.MeasuringSystem
 import com.gu.recipe.generated.*
 import com.gu.recipe.scaleAndConvertUnitRecipe
+import com.gu.recipe.textWithoutSuffix
 import com.gu.recipe.wrapWithStrongTag
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -91,7 +92,7 @@ class ScaleRecipeTest {
 
     @Test
     fun `textWithoutSuffix returns first part of the ingredient`() {
-        val ingredient = IngredientItem(text = "1 potato, (100g) thinly chopped")
-        assertEquals("1 potato", ingredient.textWithoutSuffix())
+        val ingredient = "1 potato, (100g) thinly chopped"
+        assertEquals("1 potato", textWithoutSuffix(ingredient))
     }
 }

--- a/library/src/commonTest/kotlin/com/gu/recipe/ScaleRecipeTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/ScaleRecipeTest.kt
@@ -3,7 +3,7 @@ package io.github.kotlin.fibonacci.com.gu.recipe
 import com.gu.recipe.unit.MeasuringSystem
 import com.gu.recipe.generated.*
 import com.gu.recipe.scaleAndConvertUnitRecipe
-import com.gu.recipe.textWithoutSuffix
+import com.gu.recipe.ingredientWithoutSuffix
 import com.gu.recipe.wrapWithStrongTag
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -93,6 +93,6 @@ class ScaleRecipeTest {
     @Test
     fun `textWithoutSuffix returns first part of the ingredient`() {
         val ingredient = "1 potato, (100g) thinly chopped"
-        assertEquals("1 potato", textWithoutSuffix(ingredient))
+        assertEquals("1 potato", ingredientWithoutSuffix(ingredient))
     }
 }

--- a/library/src/commonTest/kotlin/com/gu/recipe/ScaleRecipeTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/ScaleRecipeTest.kt
@@ -88,4 +88,10 @@ class ScaleRecipeTest {
         assertEquals("<strong>1-2 of something</strong>", wrapWithStrongTag("1-2 of something"))
         assertEquals("<strong>1-2 kg oranges</strong>, organic", wrapWithStrongTag("1-2 kg oranges, organic"))
     }
+
+    @Test
+    fun `textWithoutSuffix returns first part of the ingredient`() {
+        val ingredient = IngredientItem(text = "1 potato, (100g) thinly chopped")
+        assertEquals("1 potato", ingredient.textWithoutSuffix())
+    }
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
In the app, the Shopping List screen needs to show only the part of the ingredient, specifically without the suffix of the ingredient line. In this PR, a small helper method has been added specifically for this purpose. 

Also, to keep the text highlighter logic (using `strong`) consistent, we now use the same text split logic.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Make sure tests are passing.


