### PR TITLE
Filter ingredient suffix properly

### DIFF
--- a/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
@@ -99,11 +99,11 @@ private fun splitBeforeSuffix(value: String): Pair<String, String?> {
     val index = value.indexOfAny(separators)
 
     return if (index != -1) {
-        val before = value.take(index).trim()
-        val after = value.substring(index).trim()
+        val before = value.take(index)
+        val after = value.drop(index)
         before to after
     } else {
-        value to null
+        value.trim() to null
     }
 }
 
@@ -147,5 +147,5 @@ fun scaleAndConvertUnitRecipe(recipe: RecipeV3, factor: Float, measuringSystem: 
 
 fun ingredientWithoutSuffix(renderedTemplate: String): String {
     val (before, _) = splitBeforeSuffix(renderedTemplate)
-    return before
+    return before.trim()
 }

--- a/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
@@ -94,11 +94,24 @@ internal fun renderTemplate(template: ParsedTemplate, factor: Float, measuringSy
     return applySmartPunctuation(renderedParts.joinToString(""))
 }
 
-internal fun wrapWithStrongTag(value: String): String {
-    val before = ingredientWithoutSuffix(value)
-    val after = value.substring(before.length)
-    return """<strong>$before</strong>$after"""
+private fun splitBeforeSuffix(value: String): Pair<String, String?> {
+    val separators = charArrayOf(',', ';', '(')
+    val index = value.indexOfAny(separators)
+
+    return if (index != -1) {
+        val before = value.take(index).trim()
+        val after = value.substring(index).trim()
+        before to after
+    } else {
+        value to null
+    }
 }
+
+internal fun wrapWithStrongTag(value: String): String {
+    val (before, after) = splitBeforeSuffix(value)
+    return "<strong>$before</strong>${after.orEmpty()}"
+}
+
 
 /**
  * scaleAndConvertUnitRecipe used to convert units and scale recipe
@@ -133,5 +146,6 @@ fun scaleAndConvertUnitRecipe(recipe: RecipeV3, factor: Float, measuringSystem: 
 }
 
 fun ingredientWithoutSuffix(renderedTemplate: String): String {
-    return renderedTemplate.substringBefore(",")
+    val (before, _) = splitBeforeSuffix(renderedTemplate)
+    return before
 }

--- a/library/src/commonTest/kotlin/com/gu/recipe/ScaleRecipeTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/ScaleRecipeTest.kt
@@ -94,5 +94,8 @@ class ScaleRecipeTest {
     fun `textWithoutSuffix returns first part of the ingredient`() {
         val ingredient = "1 potato, (100g) thinly chopped"
         assertEquals("1 potato", ingredientWithoutSuffix(ingredient))
+
+        val ingredient2 = "150 g mayonnaise (homemade or shop-bought)"
+        assertEquals("150 g mayonnaise", ingredientWithoutSuffix(ingredient2))
     }
 }

--- a/library/src/commonTest/kotlin/com/gu/recipe/ScaleRecipeTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/ScaleRecipeTest.kt
@@ -88,6 +88,7 @@ class ScaleRecipeTest {
     fun `wrapWithStrongTag should wrap text before first punctuation`() {
         assertEquals("<strong>1-2 of something</strong>", wrapWithStrongTag("1-2 of something"))
         assertEquals("<strong>1-2 kg oranges</strong>, organic", wrapWithStrongTag("1-2 kg oranges, organic"))
+        assertEquals("<strong>150 g mayonnaise </strong>(homemade or shop-bought)", wrapWithStrongTag("150 g mayonnaise (homemade or shop-bought)"))
     }
 
     @Test
@@ -97,5 +98,8 @@ class ScaleRecipeTest {
 
         val ingredient2 = "150 g mayonnaise (homemade or shop-bought)"
         assertEquals("150 g mayonnaise", ingredientWithoutSuffix(ingredient2))
+
+        val ingredient3 = "150 g egg; (small)"
+        assertEquals("150 g egg", ingredientWithoutSuffix(ingredient3))
     }
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
In the app, the Shopping List screen needs to show only the part of the ingredient, specifically without the suffix of the ingredient line. In this PR, I updated a small helper method for this purpose.

In a previous [PR](https://github.com/guardian/feast-multiplatform-library/pull/24) this helper method was added in too simplistic way which does not cover all scenario - in someway this PR revert those changes but make it reusable.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
- Make sure tests are passing.
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
