### PR TITLE
Fix git permissions in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,7 @@ jobs:
         run: |
           git config --local user.email "${{ steps.get-user-id.outputs.user-id }}+${{ steps.create-app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
           git config --local user.name "${{ steps.create-app-token.outputs.app-slug }}[bot]"
+          git remote set-url origin https://x-access-token:${{ steps.create-app-token.outputs.token }}@github.com/${{ github.repository }}.git
           git add Package.swift
           git commit -m "Update Package.swift for release ${{ steps.version.outputs.VERSION }}"
           git push

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "FeastMultiplatformLibrary",
-            url: "https://github.com/guardian/feast-multiplatform-library/releases/download/7.0.0/FeastMultiplatformLibrary.xcframework.zip",
-            checksum:"87e015b14bd56a0587e3c63494904c9cb50640f56904bea2eb18a16ba5ec7758")
+            url: "https://github.com/guardian/feast-multiplatform-library/releases/download/8.0.0/FeastMultiplatformLibrary.xcframework.zip",
+            checksum:"31cd87b5ba137807d14df343bbc862aa0bf383f8340720787cce38353e8e7e35")
     ]
 )


### PR DESCRIPTION
## What does this change?

Fixes the permissions issue that was blocking the iOS library release - by safely using the exchanged token for `git push` (not a fudge 😁 )

## How to test

Run the release process for this branch.  It takes forever and uses a version number, so I did it already: https://github.com/guardian/feast-multiplatform-library/actions/runs/21285369882

Now, the npm release failed - but that is unrelated to the change in question and most likely related to the fact that I've used a release on a branch and without code changes.  So I expect that it will work fine and if not that issue can be picked up seperately.

## How can we measure success?

Unblock iOS release process

## Have we considered potential risks?

n/a

