### PR TITLE
Give GitHub app permission to raise PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,7 @@ jobs:
           private-key: ${{ secrets.GU_SWIFT_LIBRARY_RELEASE_PRIVATE_KEY }}
           owner: guardian
           permission-contents: write
+          permission-pull-requests: write
 
       - name: Get GitHub User ID
         id: get-user-id


### PR DESCRIPTION
This is to fix the [failing release workflow](https://github.com/guardian/feast-multiplatform-library/actions/runs/21297348073/job/61307334291#step:12:22).