### PR TITLE
Added a utility method to combine ingredients

### DIFF
--- a/library/src/commonTest/kotlin/com/gu/recipe/CombineIngredientsTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/CombineIngredientsTest.kt
@@ -1,0 +1,171 @@
+package com.gu.recipe
+
+import com.gu.recipe.density.DensityTable
+import com.gu.recipe.generated.IngredientItem
+import com.gu.recipe.generated.IngredientsList
+import com.gu.recipe.generated.RecipeV3
+import com.gu.recipe.unit.MeasuringSystem
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CombineIngredientsTest {
+    private fun recipeWithIngredients(vararg templates: String): RecipeV3 {
+        return RecipeV3(
+            id = "test-recipe",
+            ingredients = listOf(
+                IngredientsList(
+                    ingredientsList = templates.map { template ->
+                        IngredientItem(template = template)
+                    }
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `combine ingredients with same unit`() {
+        val recipe1 = recipeWithIngredients(
+            """{"min": 2, "scale": true, "ingredient": "egg"} egg"""
+        )
+        val recipe2 = recipeWithIngredients(
+            """{"min": 6, "scale": true, "ingredient": "egg"} egg"""
+        )
+
+        val session = TemplateSession(DensityTable("test", HashMap(), HashMap()))
+        val combined = session.combineIngredients(
+            recipes = listOf(recipe1, recipe2),
+            measuringSystem = MeasuringSystem.Metric
+        )
+
+        assertEquals(listOf("8 egg"), combined)
+    }
+
+    @Test
+    fun `keep different units separate`() {
+        val recipe1 = recipeWithIngredients(
+            """{"min": 100, "unit": "g", "scale": true, "ingredient": "flour"} flour"""
+        )
+        val recipe2 = recipeWithIngredients(
+            """{"min": 1, "unit": "cup", "scale": true, "ingredient": "flour"} flour"""
+        )
+
+        val session = TemplateSession(DensityTable("test", HashMap(), HashMap()))
+        val combined = session.combineIngredients(
+            recipes = listOf(recipe1, recipe2),
+            measuringSystem = MeasuringSystem.Metric
+        )
+
+        assertEquals(listOf("1 cup flour", "100 g flour"), combined)
+    }
+
+    @Test
+    fun `combine ranges by summing min and max separately`() {
+        val recipe1 = recipeWithIngredients(
+            """{"min": 1, "max": 2, "unit": "tbsp", "scale": true, "ingredient": "sugar"} sugar"""
+        )
+        val recipe2 = recipeWithIngredients(
+            """{"min": 2, "max": 3, "unit": "tbsp", "scale": true, "ingredient": "sugar"} sugar"""
+        )
+
+        val session = TemplateSession(DensityTable("test", HashMap(), HashMap()))
+        val combined = session.combineIngredients(
+            recipes = listOf(recipe1, recipe2),
+            measuringSystem = MeasuringSystem.Metric
+        )
+
+        assertEquals(listOf("3-5 tbsp sugar"), combined)
+    }
+
+    @Test
+    fun `include count when requested and more than one item`() {
+        val recipe1 = recipeWithIngredients(
+            """{"min": 2, "scale": true, "ingredient": "egg"} egg"""
+        )
+        val recipe2 = recipeWithIngredients(
+            """{"min": 4, "scale": true, "ingredient": "egg"} egg"""
+        )
+        val recipe3 = recipeWithIngredients(
+            """{"min": 100, "unit": "g", "scale": true, "ingredient": "flour"} flour"""
+        )
+
+        val session = TemplateSession(DensityTable("test", HashMap(), HashMap()))
+        val combined = session.combineIngredients(
+            recipes = listOf(recipe1, recipe2, recipe3),
+            measuringSystem = MeasuringSystem.Metric,
+            includeCount = true
+        )
+
+        assertEquals(listOf("6 egg (2)", "100 g flour"), combined)
+    }
+
+    @Test
+    fun `combine unitless ingredients`() {
+        val recipe1 = recipeWithIngredients(
+            """{"min": 3, "scale": true, "ingredient": "egg"} egg"""
+        )
+        val recipe2 = recipeWithIngredients(
+            """{"min": 5, "scale": true, "ingredient": "egg"} egg"""
+        )
+
+        val session = TemplateSession(DensityTable("test", HashMap(), HashMap()))
+        val combined = session.combineIngredients(
+            recipes = listOf(recipe1, recipe2),
+            measuringSystem = MeasuringSystem.Metric
+        )
+
+        assertEquals(listOf("8 egg"), combined)
+    }
+
+    @Test
+    fun `skip ingredients without template`() {
+        val recipeWithoutTemplate = RecipeV3(
+            id = "test",
+            ingredients = listOf(
+                IngredientsList(
+                    ingredientsList = listOf(
+                        IngredientItem(text = "2 eggs", template = null)
+                    )
+                )
+            )
+        )
+        val recipeWithTemplate = recipeWithIngredients(
+            """{"min": 3, "scale": true, "ingredient": "egg"} egg"""
+        )
+
+        val session = TemplateSession(DensityTable("test", HashMap(), HashMap()))
+        val combined = session.combineIngredients(
+            recipes = listOf(recipeWithoutTemplate, recipeWithTemplate),
+            measuringSystem = MeasuringSystem.Metric
+        )
+
+        // Only the one with template is included
+        assertEquals(listOf("3 egg"), combined)
+    }
+
+    @Test
+    fun `skip ingredients without normalized name`() {
+        val recipe = recipeWithIngredients(
+            """{"min": 100, "unit": "g", "scale": true} some flour"""
+        )
+
+        val session = TemplateSession(DensityTable("test", HashMap(), HashMap()))
+        val combined = session.combineIngredients(
+            recipes = listOf(recipe),
+            measuringSystem = MeasuringSystem.Metric
+        )
+
+        // Skipped because no "ingredient" field
+        assertEquals(emptyList(), combined)
+    }
+
+    @Test
+    fun `empty input returns empty list`() {
+        val session = TemplateSession(DensityTable("test", HashMap(), HashMap()))
+        val combined = session.combineIngredients(
+            recipes = emptyList(),
+            measuringSystem = MeasuringSystem.Metric
+        )
+
+        assertEquals(emptyList(), combined)
+    }
+}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This PR introduce a new method that allows to merge quantities of same ingredients across recipes. This is helpful for SL to allow users to see all same ingredients together. So, a user, instead of seeing this:
```
2 Eggs
3 Eggs 
```

They will see
```
5 Eggs
```

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?
Sample console output (butter and milk are combined) for a single recipe:
food/2019/apr/13/four-easter-chocolate-paul-a-young-recipes-desserts-torte-truffles-cake-praline
```
=== Combined Ingredients ===
 • ½ tsp bicarbonate of soda
 • 365 g butter (2)
 • 225 g caster sugar
 • 100 g chocolate
 • 70 g cocoa powder
 • 100 g dark chocolate
 • 1 easter egg
 • 2 egg
 • 195 ml evaporated milk (2)
 • 500 g icing sugar
 • ½ tsp salt
 • 185 g self-raising flour
 • 145 ml water
 ```

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
