### PR TITLE
add "US customary" to units for javascript stubs

### DIFF
--- a/library/src/jsMain/kotlin/com/gu/recipe/js/ScaleRecipeJsContract.kt
+++ b/library/src/jsMain/kotlin/com/gu/recipe/js/ScaleRecipeJsContract.kt
@@ -21,6 +21,7 @@ fun scaleRecipe(recipe: String, factor: Float, unit: String, session: TemplateSe
     val measuringSystem = when (unit) {
         "Imperial" -> MeasuringSystem.Imperial
         "Metric" -> MeasuringSystem.Metric
+        "US" -> MeasuringSystem.USCustomary
         else -> throw IllegalArgumentException("Unknown unit: $unit")
     }
     val scaledRecipe = session.scaleAndConvertUnitRecipe(parsedRecipe, factor, measuringSystem)


### PR DESCRIPTION
## What does this change?

Adds "US" as a supported unit to the javascript stub, mapping to `MeasuringSystem.USCustomary`

## How to test

n/a

## How can we measure success?

Able to render properly in JS

## Have we considered potential risks?

n/a
