### PR TITLE
Add cooktime util

### DIFF
--- a/library/src/commonMain/kotlin/com/gu/recipe/CookTimeUtils.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/CookTimeUtils.kt
@@ -56,16 +56,27 @@ object CookTimeUtils {
         }
     }
 
-    data class CooktimeInfo(
+    /**
+     * Combined display model containing primary cook time and passive secondary timings.
+     */
+    data class CookTimeInfo(
         val primary: CookDuration?,
         val secondary: List<Pair<String, CookDuration>>
     )
 
+    /**
+     * A labeled [CookDuration] entry used for a single timing.
+     */
     data class LabeledCookDuration(
         val label: String,
         val duration: CookDuration
     )
 
+    /**
+     * Uncombined timing model with primary entries, fallback entry, and passive entries.
+     * Useful when apps need to render individual timing entries while preserving formatter output (i.e. in recipe
+     * page).
+     */
     data class StructuredIndividualInfo(
         val primary: List<LabeledCookDuration>,
         val fallback: LabeledCookDuration?,
@@ -93,7 +104,7 @@ object CookTimeUtils {
         return "$primaryString + $secondaryString"
     }
 
-    fun structured(timings: List<Timing>): CooktimeInfo {
+    fun structured(timings: List<Timing>): CookTimeInfo {
         val individual = structuredIndividual(timings)
         val combinedPrimary = when {
             individual.primary.isNotEmpty() -> CookDuration(individual.primary.sumOf { it.duration.minutes })
@@ -105,7 +116,7 @@ object CookTimeUtils {
         } else {
             emptyList()
         }
-        return CooktimeInfo(primary = combinedPrimary, secondary = secondary)
+        return CookTimeInfo(primary = combinedPrimary, secondary = secondary)
     }
 
     /* ----------------------------- */

--- a/library/src/commonMain/kotlin/com/gu/recipe/CookTimeUtils.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/CookTimeUtils.kt
@@ -86,5 +86,130 @@ class CookTimeUtils {
         val secondary: List<LabeledCookDuration>
     )
 
+    /* ----------------------------- */
+    /* PUBLIC API                    */
+    /* ----------------------------- */
 
+    fun format(
+        timings: List<RecipeTiming>,
+    ): String? {
+        val info = structured(timings)
+
+        val primary = info.primary ?: return null
+        val primaryString = primary.format()
+
+        if (info.secondary.isEmpty()) return primaryString
+
+        val secondaryString = info.secondary.joinToString(" + ") {
+            "${it.first} ${formatPassiveDuration(it.second.minutes)}"
+        }
+
+        return "$primaryString + $secondaryString"
+    }
+
+    fun structured(timings: List<RecipeTiming>): CooktimeInfo {
+        val individual = structuredIndividual(timings)
+        val combinedPrimary = when {
+            individual.primary.isNotEmpty() -> CookDuration(individual.primary.sumOf { it.duration.minutes })
+            individual.fallback != null -> individual.fallback.duration
+            else -> null
+        }
+        val secondary = if (individual.primary.isNotEmpty()) {
+            individual.secondary.map { it.label to it.duration }
+        } else {
+            emptyList()
+        }
+        return CooktimeInfo(primary = combinedPrimary, secondary = secondary)
+    }
+
+    /* ----------------------------- */
+    /* MAPPING                       */
+    /* ----------------------------- */
+
+    private fun DurationRange.toCookDuration(): CookDuration? {
+        // Source may contain ranges; display uses a single value, so we prioritise min.
+        val minutes = (min ?: max)?.toRoundedMinutes() ?: return null
+        if (minutes <= 0) return null
+        return CookDuration(minutes)
+    }
+
+    private fun Double.toRoundedMinutes(): Int = roundToInt()
+
+    private fun RecipeTiming.toTiming(): Timing? {
+        val duration = durationInMins?.toCookDuration() ?: return null
+        val isPrimary = qualifier in PRIMARY_QUALIFIERS
+        val isFallback = qualifier in TOTAL_QUALIFIERS || qualifier in READY_IN_QUALIFIERS
+        val passiveLabel = PASSIVE_LABELS[qualifier] ?: qualifier.toPassiveLabelOrNull()
+        if (!isPrimary && !isFallback && passiveLabel == null) return null
+
+        return Timing(
+            qualifier = qualifier,
+            passiveLabel = passiveLabel,
+            minutes = duration.minutes
+        )
+    }
+
+    private fun String.toPassiveLabelOrNull(): String? {
+        if (!endsWith("-time")) return null
+        if (this in PRIMARY_QUALIFIERS || this in TOTAL_QUALIFIERS || this in READY_IN_QUALIFIERS) {
+            return null
+        }
+        return removeSuffix("-time").lowercase()
+    }
+
+    private fun formatPassiveDuration(minutes: Int): String {
+        // Spec requires Unicode vulgar fractions when passive durations are represented in days.
+        val fractionText = minutes.toFractionalDayTextOrNull()
+        return fractionText ?: CookDuration(minutes).format()
+    }
+
+    private fun Int.toFractionalDayTextOrNull(): String? {
+        if (this !in 1..<MINUTES_PER_DAY) return null
+        if (this % MINUTES_PER_QUARTER_DAY != 0) return null
+
+        return when (this / MINUTES_PER_QUARTER_DAY) {
+            1 -> "¼ day"
+            2 -> "½ day"
+            3 -> "¾ day"
+            else -> null
+        }
+    }
+
+    fun structuredIndividual(timings: List<RecipeTiming>): StructuredIndividualInfo {
+        val mapped = timings.mapNotNull { it.toTiming() }
+
+        val primary = mapped
+            .filter { it.qualifier in PRIMARY_QUALIFIERS }
+            .map { timing ->
+                val label = if (timing.qualifier == "prep-time") "prep" else "cook"
+                LabeledCookDuration(label = label, duration = CookDuration(timing.minutes))
+            }
+
+        val fallback = if (primary.isEmpty()) {
+            val fallbackTiming = mapped.firstOrNull { it.qualifier in TOTAL_QUALIFIERS }
+                ?: mapped.firstOrNull { it.qualifier in READY_IN_QUALIFIERS }
+            fallbackTiming?.let {
+                val label = if (it.qualifier in TOTAL_QUALIFIERS) "total" else "ready-in"
+                LabeledCookDuration(label = label, duration = CookDuration(it.minutes))
+            }
+        } else {
+            null
+        }
+
+        val secondary = if (primary.isNotEmpty()) {
+            mapped.mapNotNull { timing ->
+                timing.passiveLabel?.let { label ->
+                    LabeledCookDuration(label = label, duration = CookDuration(timing.minutes))
+                }
+            }
+        } else {
+            emptyList()
+        }
+
+        return StructuredIndividualInfo(
+            primary = primary,
+            fallback = fallback,
+            secondary = secondary
+        )
+    }
 }

--- a/library/src/commonMain/kotlin/com/gu/recipe/CookTimeUtils.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/CookTimeUtils.kt
@@ -1,5 +1,6 @@
 package com.gu.recipe
 
+import com.gu.recipe.generated.Range
 import kotlin.math.roundToInt
 
 /**
@@ -17,25 +18,23 @@ import kotlin.math.roundToInt
  * `structured()` returns the display model with combined primary timing.
  * `structuredIndividual()` returns individual prep/cook entries without combining.
  */
-class CookTimeUtils {
-    private companion object {
-        const val MINUTES_PER_HOUR = 60
-        const val MINUTES_PER_DAY = 1440
-        const val MINUTES_PER_QUARTER_DAY = 360
-        val PRIMARY_QUALIFIERS = setOf("prep-time", "cook-time")
-        val TOTAL_QUALIFIERS = setOf("total-time")
-        val READY_IN_QUALIFIERS = setOf("ready-in", "ready-in-time")
-        val PASSIVE_LABELS = mapOf(
-            "chill-time" to "chill",
-            "marinate-time" to "marinate",
-            "freeze-time" to "freeze",
-            "prove-time" to "prove",
-            "rest-time" to "rest",
-            "soak-time" to "soak",
-            "set-time" to "set",
-            "cool-time" to "cool"
-        )
-    }
+object CookTimeUtils {
+    private const val MINUTES_PER_HOUR = 60
+    private const val MINUTES_PER_DAY = 1440
+    private const val MINUTES_PER_QUARTER_DAY = 360
+    private val PRIMARY_QUALIFIERS = setOf("prep-time", "cook-time")
+    private val TOTAL_QUALIFIERS = setOf("total-time")
+    private val READY_IN_QUALIFIERS = setOf("ready-in", "ready-in-time")
+    private val PASSIVE_LABELS = mapOf(
+        "chill-time" to "chill",
+        "marinate-time" to "marinate",
+        "freeze-time" to "freeze",
+        "prove-time" to "prove",
+        "rest-time" to "rest",
+        "soak-time" to "soak",
+        "set-time" to "set",
+        "cool-time" to "cool"
+    )
 
     /* ----------------------------- */
     /* API MODELS                    */
@@ -43,12 +42,7 @@ class CookTimeUtils {
 
     data class RecipeTiming(
         val qualifier: String,
-        val durationInMins: DurationRange?
-    )
-
-    data class DurationRange(
-        val min: Double?,
-        val max: Double?
+        val durationInMins: Range?
     )
 
     /* ----------------------------- */
@@ -126,7 +120,7 @@ class CookTimeUtils {
     /* MAPPING                       */
     /* ----------------------------- */
 
-    private fun DurationRange.toCookDuration(): CookDuration? {
+    private fun Range.toCookDuration(): CookDuration? {
         // Source may contain ranges; display uses a single value, so we prioritise min.
         val minutes = (min ?: max)?.toRoundedMinutes() ?: return null
         if (minutes <= 0) return null

--- a/library/src/commonMain/kotlin/com/gu/recipe/CookTimeUtils.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/CookTimeUtils.kt
@@ -1,0 +1,39 @@
+package com.gu.recipe
+
+import kotlin.math.roundToInt
+
+/**
+ * Formats recipe timing metadata into Feast cook-time display strings.
+ *
+ * Rules are applied in priority order:
+ * - primary from prep/cook (combined),
+ * - otherwise total-time,
+ * - otherwise ready-in,
+ * - otherwise no display.
+ *
+ * Passive timings are appended with " + " only when a prep/cook primary exists.
+ * Output uses fixed `hr`/`min` units and supports Unicode day fractions for passive quarter-day values.
+ *
+ * `structured()` returns the display model with combined primary timing.
+ * `structuredIndividual()` returns individual prep/cook entries without combining.
+ */
+class CookTimeUtils {
+    private companion object {
+        const val MINUTES_PER_HOUR = 60
+        const val MINUTES_PER_DAY = 1440
+        const val MINUTES_PER_QUARTER_DAY = 360
+        val PRIMARY_QUALIFIERS = setOf("prep-time", "cook-time")
+        val TOTAL_QUALIFIERS = setOf("total-time")
+        val READY_IN_QUALIFIERS = setOf("ready-in", "ready-in-time")
+        val PASSIVE_LABELS = mapOf(
+            "chill-time" to "chill",
+            "marinate-time" to "marinate",
+            "freeze-time" to "freeze",
+            "prove-time" to "prove",
+            "rest-time" to "rest",
+            "soak-time" to "soak",
+            "set-time" to "set",
+            "cool-time" to "cool"
+        )
+    }
+}

--- a/library/src/commonMain/kotlin/com/gu/recipe/CookTimeUtils.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/CookTimeUtils.kt
@@ -1,6 +1,7 @@
 package com.gu.recipe
 
 import com.gu.recipe.generated.Range
+import com.gu.recipe.generated.Timing
 import kotlin.math.roundToInt
 
 /**
@@ -37,19 +38,10 @@ object CookTimeUtils {
     )
 
     /* ----------------------------- */
-    /* API MODELS                    */
-    /* ----------------------------- */
-
-    data class RecipeTiming(
-        val qualifier: String,
-        val durationInMins: Range?
-    )
-
-    /* ----------------------------- */
     /* DOMAIN TYPES                  */
     /* ----------------------------- */
 
-    private data class Timing(
+    private data class ParsedTiming(
         val qualifier: String,
         val passiveLabel: String?,
         val minutes: Int
@@ -85,7 +77,7 @@ object CookTimeUtils {
     /* ----------------------------- */
 
     fun format(
-        timings: List<RecipeTiming>,
+        timings: List<Timing>,
     ): String? {
         val info = structured(timings)
 
@@ -101,7 +93,7 @@ object CookTimeUtils {
         return "$primaryString + $secondaryString"
     }
 
-    fun structured(timings: List<RecipeTiming>): CooktimeInfo {
+    fun structured(timings: List<Timing>): CooktimeInfo {
         val individual = structuredIndividual(timings)
         val combinedPrimary = when {
             individual.primary.isNotEmpty() -> CookDuration(individual.primary.sumOf { it.duration.minutes })
@@ -129,15 +121,16 @@ object CookTimeUtils {
 
     private fun Double.toRoundedMinutes(): Int = roundToInt()
 
-    private fun RecipeTiming.toTiming(): Timing? {
+    private fun Timing.toParsedTiming(): ParsedTiming? {
         val duration = durationInMins?.toCookDuration() ?: return null
-        val isPrimary = qualifier in PRIMARY_QUALIFIERS
-        val isFallback = qualifier in TOTAL_QUALIFIERS || qualifier in READY_IN_QUALIFIERS
-        val passiveLabel = PASSIVE_LABELS[qualifier] ?: qualifier.toPassiveLabelOrNull()
+        val qualifierValue = qualifier ?: return null
+        val isPrimary = qualifierValue in PRIMARY_QUALIFIERS
+        val isFallback = qualifierValue in TOTAL_QUALIFIERS || qualifierValue in READY_IN_QUALIFIERS
+        val passiveLabel = PASSIVE_LABELS[qualifierValue] ?: qualifierValue.toPassiveLabelOrNull()
         if (!isPrimary && !isFallback && passiveLabel == null) return null
 
-        return Timing(
-            qualifier = qualifier,
+        return ParsedTiming(
+            qualifier = qualifierValue,
             passiveLabel = passiveLabel,
             minutes = duration.minutes
         )
@@ -169,8 +162,8 @@ object CookTimeUtils {
         }
     }
 
-    fun structuredIndividual(timings: List<RecipeTiming>): StructuredIndividualInfo {
-        val mapped = timings.mapNotNull { it.toTiming() }
+    fun structuredIndividual(timings: List<Timing>): StructuredIndividualInfo {
+        val mapped = timings.mapNotNull { it.toParsedTiming() }
 
         val primary = mapped
             .filter { it.qualifier in PRIMARY_QUALIFIERS }

--- a/library/src/commonMain/kotlin/com/gu/recipe/CookTimeUtils.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/CookTimeUtils.kt
@@ -36,4 +36,55 @@ class CookTimeUtils {
             "cool-time" to "cool"
         )
     }
+
+    /* ----------------------------- */
+    /* API MODELS                    */
+    /* ----------------------------- */
+
+    data class RecipeTiming(
+        val qualifier: String,
+        val durationInMins: DurationRange?
+    )
+
+    data class DurationRange(
+        val min: Double?,
+        val max: Double?
+    )
+
+    /* ----------------------------- */
+    /* DOMAIN TYPES                  */
+    /* ----------------------------- */
+
+    private data class Timing(
+        val qualifier: String,
+        val passiveLabel: String?,
+        val minutes: Int
+    )
+
+    data class CookDuration(val minutes: Int) {
+        fun format(): String {
+            if (minutes < MINUTES_PER_HOUR) return "$minutes min"
+            val hours = minutes / MINUTES_PER_HOUR
+            val remainder = minutes % MINUTES_PER_HOUR
+            return if (remainder == 0) "$hours hr" else "$hours hr $remainder min"
+        }
+    }
+
+    data class CooktimeInfo(
+        val primary: CookDuration?,
+        val secondary: List<Pair<String, CookDuration>>
+    )
+
+    data class LabeledCookDuration(
+        val label: String,
+        val duration: CookDuration
+    )
+
+    data class StructuredIndividualInfo(
+        val primary: List<LabeledCookDuration>,
+        val fallback: LabeledCookDuration?,
+        val secondary: List<LabeledCookDuration>
+    )
+
+
 }

--- a/library/src/commonTest/kotlin/com/gu/recipe/CookTimeUtilsTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/CookTimeUtilsTest.kt
@@ -1,0 +1,343 @@
+package com.gu.recipe
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class CookTimeUtilsTest {
+
+    private val utils = CookTimeUtils()
+
+    @Test
+    fun `prep + cook sums correctly`() {
+        val input = listOf(
+            timing("prep-time", 10),
+            timing("cook-time", 20)
+        )
+
+        val result = utils.format(input)
+
+        assertEquals("30 min", result)
+    }
+
+    @Test
+    fun `total time overrides prep and cook`() {
+        val input = listOf(
+            timing("prep-time", 10),
+            timing("cook-time", 20),
+            timing("total-time", 25)
+        )
+
+        val result = utils.format(input)
+
+        assertEquals("30 min", result)
+    }
+
+    @Test
+    fun `passive timing appended correctly`() {
+        val input = listOf(
+            timing("prep-time", 45),
+            timing("chill-time", 30)
+        )
+
+        val result = utils.format(input)
+
+        assertEquals("45 min + chill 30 min", result)
+    }
+
+    @Test
+    fun `passive only returns null`() {
+        val input = listOf(
+            timing("chill-time", 60)
+        )
+
+        val result = utils.format(input)
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `long duration stays in hr format`() {
+        val input = listOf(
+            timing("prep-time", 4320), // 3 days
+            timing("cook-time", 60)
+        )
+
+        val result = utils.format(input)
+
+        assertEquals("73 hr", result)
+    }
+
+    @Test
+    fun `primary time crossing twenty four hours stays in hr format`() {
+        val input = listOf(
+            timing("prep-time", 900),  // 15 hr
+            timing("cook-time", 600)   // 10 hr
+        )
+
+        val result = utils.format(input)
+
+        assertEquals("25 hr", result)
+    }
+
+    @Test
+    fun `single value displays minutes`() {
+        val input = listOf(timing("prep-time", 10))
+        assertEquals("10 min", utils.format(input))
+    }
+
+    @Test
+    fun `hours and minutes displays with fixed labels`() {
+        val input = listOf(
+            timing("prep-time", 15),
+            timing("cook-time", 90)
+        )
+        assertEquals("1 hr 45 min", utils.format(input))
+    }
+
+    @Test
+    fun `hours only combination displays in hr`() {
+        val input = listOf(
+            timing("prep-time", 30),
+            timing("cook-time", 90)
+        )
+        assertEquals("2 hr", utils.format(input))
+    }
+
+    @Test
+    fun `hours do not pluralise`() {
+        val input = listOf(timing("cook-time", 120))
+        assertEquals("2 hr", utils.format(input))
+    }
+
+    @Test
+    fun `total fallback works when no prep cook`() {
+        val input = listOf(
+            timing("total-time", 90),
+            timing("chill-time", 30)
+        )
+        assertEquals("1 hr 30 min", utils.format(input))
+    }
+
+    @Test
+    fun `ready in fallback works when no prep cook and no total`() {
+        val input = listOf(timing("ready-in", 30))
+        assertEquals("30 min", utils.format(input))
+    }
+
+    @Test
+    fun `multiple passive timings append in sequence`() {
+        val input = listOf(
+            timing("prep-time", 20),
+            timing("cook-time", 40),
+            timing("marinate-time", 120),
+            timing("chill-time", 30)
+        )
+        assertEquals("1 hr + marinate 2 hr + chill 30 min", utils.format(input))
+    }
+
+    @Test
+    fun `fractional passive day uses unicode fraction`() {
+        val input = listOf(
+            timing("prep-time", 80),
+            timing("marinate-time", 720)
+        )
+        assertEquals("1 hr 20 min + marinate ½ day", utils.format(input))
+    }
+
+    @Test
+    fun `fractional passive day supports quarter and three quarters`() {
+        val quarter = listOf(
+            timing("prep-time", 30),
+            timing("rest-time", 360)
+        )
+        val threeQuarters = listOf(
+            timing("prep-time", 30),
+            timing("prove-time", 1080)
+        )
+
+        assertEquals("30 min + rest ¼ day", utils.format(quarter))
+        assertEquals("30 min + prove ¾ day", utils.format(threeQuarters))
+    }
+
+    @Test
+    fun `unknown passive qualifier follows passive pattern`() {
+        val input = listOf(
+            timing("prep-time", 30),
+            timing("ferment-time", 180)
+        )
+        assertEquals("30 min + ferment 3 hr", utils.format(input))
+    }
+
+    @Test
+    fun `combined minutes above fifty nine convert to hour minute format`() {
+        val input = listOf(
+            timing("prep-time", 30),
+            timing("cook-time", 40)
+        )
+
+        assertEquals("1 hr 10 min", utils.format(input))
+    }
+
+    @Test
+    fun `decimal minute values round and do not display decimals`() {
+        val input = listOf(
+            CookTimeUtils.RecipeTiming(
+                qualifier = "total-time",
+                durationInMins = CookTimeUtils.DurationRange(min = 89.6, max = null)
+            )
+        )
+
+        assertEquals("1 hr 30 min", utils.format(input))
+    }
+
+    @Test
+    fun `fractional hour source values convert to hr and min`() {
+        val input = listOf(
+            CookTimeUtils.RecipeTiming(
+                qualifier = "total-time",
+                durationInMins = CookTimeUtils.DurationRange(min = 90.0, max = 90.0)
+            )
+        )
+
+        assertEquals("1 hr 30 min", utils.format(input))
+    }
+
+    @Test
+    fun `prep only wins over total fallback`() {
+        val input = listOf(
+            timing("prep-time", 25),
+            timing("total-time", 90)
+        )
+
+        assertEquals("25 min", utils.format(input))
+    }
+
+    @Test
+    fun `cook only wins over total fallback`() {
+        val input = listOf(
+            timing("cook-time", 35),
+            timing("total-time", 90)
+        )
+
+        assertEquals("35 min", utils.format(input))
+    }
+
+    @Test
+    fun `total fallback wins over ready in fallback`() {
+        val input = listOf(
+            timing("total-time", 90),
+            timing("ready-in", 30)
+        )
+
+        assertEquals("1 hr 30 min", utils.format(input))
+    }
+
+    @Test
+    fun `fallback primary does not append passive timings`() {
+        val withTotal = listOf(
+            timing("total-time", 90),
+            timing("chill-time", 30)
+        )
+        val withReadyIn = listOf(
+            timing("ready-in", 30),
+            timing("chill-time", 30)
+        )
+
+        assertEquals("1 hr 30 min", utils.format(withTotal))
+        assertEquals("30 min", utils.format(withReadyIn))
+    }
+
+    @Test
+    fun `missing valid time data returns null`() {
+        val input = listOf(
+            CookTimeUtils.RecipeTiming(
+                qualifier = "unknown-time",
+                durationInMins = CookTimeUtils.DurationRange(min = 30.0, max = 30.0)
+            )
+        )
+        assertNull(utils.format(input))
+    }
+
+    @Test
+    fun `no time data returns null`() {
+        assertNull(utils.format(emptyList()))
+    }
+
+    @Test
+    fun `known qualifiers with no usable duration return null`() {
+        val input = listOf(
+            CookTimeUtils.RecipeTiming(
+                qualifier = "prep-time",
+                durationInMins = CookTimeUtils.DurationRange(min = null, max = null)
+            ),
+            CookTimeUtils.RecipeTiming(
+                qualifier = "cook-time",
+                durationInMins = CookTimeUtils.DurationRange(min = 0.0, max = 0.0)
+            ),
+            CookTimeUtils.RecipeTiming(
+                qualifier = "total-time",
+                durationInMins = CookTimeUtils.DurationRange(min = -10.0, max = null)
+            )
+        )
+        assertNull(utils.format(input))
+    }
+
+    @Test
+    fun `structured individual keeps prep cook separate`() {
+        val input = listOf(
+            timing("prep-time", 10),
+            timing("cook-time", 20),
+            timing("chill-time", 30)
+        )
+
+        val structured = utils.structuredIndividual(input)
+
+        assertEquals(2, structured.primary.size)
+        assertEquals("prep", structured.primary[0].label)
+        assertEquals(10, structured.primary[0].duration.minutes)
+        assertEquals("cook", structured.primary[1].label)
+        assertEquals(20, structured.primary[1].duration.minutes)
+        assertEquals(1, structured.secondary.size)
+        assertEquals("chill", structured.secondary[0].label)
+        assertEquals(30, structured.secondary[0].duration.minutes)
+        assertNull(structured.fallback)
+    }
+
+    @Test
+    fun `structured individual uses total fallback when no prep cook`() {
+        val structured = utils.structuredIndividual(
+            listOf(
+                timing("total-time", 90),
+                timing("chill-time", 20)
+            )
+        )
+
+        assertEquals(0, structured.primary.size)
+        assertEquals("total", structured.fallback?.label)
+        assertEquals(90, structured.fallback?.duration?.minutes)
+        assertEquals(0, structured.secondary.size)
+    }
+
+    @Test
+    fun `structured individual uses ready in fallback when no prep cook and no total`() {
+        val structured = utils.structuredIndividual(listOf(timing("ready-in-time", 45)))
+
+        assertEquals(0, structured.primary.size)
+        assertEquals("ready-in", structured.fallback?.label)
+        assertEquals(45, structured.fallback?.duration?.minutes)
+        assertEquals(0, structured.secondary.size)
+    }
+
+    private fun timing(
+        qualifier: String,
+        min: Int,
+        max: Int = min
+    ) = CookTimeUtils.RecipeTiming(
+        qualifier = qualifier,
+        durationInMins = CookTimeUtils.DurationRange(
+            min = min.toDouble(),
+            max = max.toDouble()
+        )
+    )
+}

--- a/library/src/commonTest/kotlin/com/gu/recipe/CookTimeUtilsTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/CookTimeUtilsTest.kt
@@ -1,6 +1,7 @@
 package com.gu.recipe
 
 import com.gu.recipe.generated.Range
+import com.gu.recipe.generated.Timing
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -183,7 +184,7 @@ class CookTimeUtilsTest {
     @Test
     fun `decimal minute values round and do not display decimals`() {
         val input = listOf(
-            CookTimeUtils.RecipeTiming(
+            Timing(
                 qualifier = "total-time",
                 durationInMins = Range(min = 89.6, max = null)
             )
@@ -195,7 +196,7 @@ class CookTimeUtilsTest {
     @Test
     fun `fractional hour source values convert to hr and min`() {
         val input = listOf(
-            CookTimeUtils.RecipeTiming(
+            Timing(
                 qualifier = "total-time",
                 durationInMins = Range(min = 90.0, max = 90.0)
             )
@@ -252,7 +253,7 @@ class CookTimeUtilsTest {
     @Test
     fun `missing valid time data returns null`() {
         val input = listOf(
-            CookTimeUtils.RecipeTiming(
+            Timing(
                 qualifier = "unknown-time",
                 durationInMins = Range(min = 30.0, max = 30.0)
             )
@@ -268,15 +269,15 @@ class CookTimeUtilsTest {
     @Test
     fun `known qualifiers with no usable duration return null`() {
         val input = listOf(
-            CookTimeUtils.RecipeTiming(
+            Timing(
                 qualifier = "prep-time",
                 durationInMins = Range(min = null, max = null)
             ),
-            CookTimeUtils.RecipeTiming(
+            Timing(
                 qualifier = "cook-time",
                 durationInMins = Range(min = 0.0, max = 0.0)
             ),
-            CookTimeUtils.RecipeTiming(
+            Timing(
                 qualifier = "total-time",
                 durationInMins = Range(min = -10.0, max = null)
             )
@@ -334,7 +335,7 @@ class CookTimeUtilsTest {
         qualifier: String,
         min: Int,
         max: Int = min
-    ) = CookTimeUtils.RecipeTiming(
+    ) = Timing(
         qualifier = qualifier,
         durationInMins = Range(
             min = min.toDouble(),

--- a/library/src/commonTest/kotlin/com/gu/recipe/CookTimeUtilsTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/CookTimeUtilsTest.kt
@@ -23,7 +23,7 @@ class CookTimeUtilsTest {
     }
 
     @Test
-    fun `total time overrides prep and cook`() {
+    fun `prep and cook take priority over total time`() {
         val input = listOf(
             timing("prep-time", 10),
             timing("cook-time", 20),

--- a/library/src/commonTest/kotlin/com/gu/recipe/CookTimeUtilsTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/CookTimeUtilsTest.kt
@@ -1,12 +1,13 @@
 package com.gu.recipe
 
+import com.gu.recipe.generated.Range
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
 class CookTimeUtilsTest {
 
-    private val utils = CookTimeUtils()
+    private val utils = CookTimeUtils
 
     @Test
     fun `prep + cook sums correctly`() {
@@ -184,7 +185,7 @@ class CookTimeUtilsTest {
         val input = listOf(
             CookTimeUtils.RecipeTiming(
                 qualifier = "total-time",
-                durationInMins = CookTimeUtils.DurationRange(min = 89.6, max = null)
+                durationInMins = Range(min = 89.6, max = null)
             )
         )
 
@@ -196,7 +197,7 @@ class CookTimeUtilsTest {
         val input = listOf(
             CookTimeUtils.RecipeTiming(
                 qualifier = "total-time",
-                durationInMins = CookTimeUtils.DurationRange(min = 90.0, max = 90.0)
+                durationInMins = Range(min = 90.0, max = 90.0)
             )
         )
 
@@ -253,7 +254,7 @@ class CookTimeUtilsTest {
         val input = listOf(
             CookTimeUtils.RecipeTiming(
                 qualifier = "unknown-time",
-                durationInMins = CookTimeUtils.DurationRange(min = 30.0, max = 30.0)
+                durationInMins = Range(min = 30.0, max = 30.0)
             )
         )
         assertNull(utils.format(input))
@@ -269,15 +270,15 @@ class CookTimeUtilsTest {
         val input = listOf(
             CookTimeUtils.RecipeTiming(
                 qualifier = "prep-time",
-                durationInMins = CookTimeUtils.DurationRange(min = null, max = null)
+                durationInMins = Range(min = null, max = null)
             ),
             CookTimeUtils.RecipeTiming(
                 qualifier = "cook-time",
-                durationInMins = CookTimeUtils.DurationRange(min = 0.0, max = 0.0)
+                durationInMins = Range(min = 0.0, max = 0.0)
             ),
             CookTimeUtils.RecipeTiming(
                 qualifier = "total-time",
-                durationInMins = CookTimeUtils.DurationRange(min = -10.0, max = null)
+                durationInMins = Range(min = -10.0, max = null)
             )
         )
         assertNull(utils.format(input))
@@ -335,7 +336,7 @@ class CookTimeUtilsTest {
         max: Int = min
     ) = CookTimeUtils.RecipeTiming(
         qualifier = qualifier,
-        durationInMins = CookTimeUtils.DurationRange(
+        durationInMins = Range(
             min = min.toDouble(),
             max = max.toDouble()
         )


### PR DESCRIPTION
## What does this change?
Implemented CookTimeUtils to standardize cook-time formatting and fallback selection across prep/cook, total, and ready-in timings, with fixed hr/min output and passive timing support.

Full spec is [here](https://docs.google.com/document/d/1wqBpTJIQC-A6V0tWi2xnnZBSUds87fVOPcmwD9nOA_Q/edit?usp=sharing)
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

There are two api/methods in this utils, see examples below
```
// Example 1: format(...) for UI-ready string
val utils = CookTimeUtils()
val formatted = utils.format(
    listOf(
        CookTimeUtils.RecipeTiming(
            qualifier = "prep-time",
            durationInMins = CookTimeUtils.DurationRange(min = 15.0, max = 15.0)
        ),
        CookTimeUtils.RecipeTiming(
            qualifier = "cook-time",
            durationInMins = CookTimeUtils.DurationRange(min = 90.0, max = 90.0)
        ),
        CookTimeUtils.RecipeTiming(
            qualifier = "chill-time",
            durationInMins = CookTimeUtils.DurationRange(min = 30.0, max = 30.0)
        )
    )
)
// formatted = "1 hr 45 min + chill 30 min"
```

Structured output:
```
// Example 2: structured(...) for separated primary/secondary model
val utils = CookTimeUtils()
val structured = utils.structured(
    listOf(
        CookTimeUtils.RecipeTiming(
            qualifier = "prep-time",
            durationInMins = CookTimeUtils.DurationRange(min = 20.0, max = 20.0)
        ),
        CookTimeUtils.RecipeTiming(
            qualifier = "cook-time",
            durationInMins = CookTimeUtils.DurationRange(min = 40.0, max = 40.0)
        ),
        CookTimeUtils.RecipeTiming(
            qualifier = "marinate-time",
            durationInMins = CookTimeUtils.DurationRange(min = 120.0, max = 120.0)
        )
    )
)

// structured.primary?.format() = "1 hr"
// structured.secondary = [("marinate", CookDuration(120))]
// structured.secondary.first().second.format() = "2 hr"
```


## How to test
Make sure all tests are passing

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
