### PR TITLE
Revert "Bump com.android.library from 8.12.3 to 9.0.1 in the android-tooling group"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "9.0.1"
+agp = "8.12.3"
 kotlin = "2.3.10"
 android-minSdk = "24"
 android-compileSdk = "36"


### PR DESCRIPTION
Reverts guardian/feast-multiplatform-library#46:

```
> Failed to apply plugin 'com.android.internal.library'.
   > The 'com.android.library' (or 'com.android.application') plugin is not compatible with the 'org.jetbrains.kotlin.multiplatform' plugin since AGP 9.0.
     Solution:
       - [Recommended] Replace the 'com.android.library' plugin with the 'com.android.kotlin.multiplatform.library' plugin (see https://developer.android.com/r/tools/built-in-kotlin).
       - Or set the Gradle property 'android.builtInKotlin=false' and 'android.newDsl=false' to temporarily bypass this issue.
```

😞 

We'll look at that update down the line.