### PR TITLE
Add style option to cooktime formatting

### DIFF
--- a/library/src/commonMain/kotlin/com/gu/recipe/CookTimeUtils.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/CookTimeUtils.kt
@@ -89,11 +89,16 @@ object CookTimeUtils {
 
     fun format(
         timings: List<Timing>,
+        withStyle: Boolean = false,
     ): String? {
         val info = structured(timings)
 
         val primary = info.primary ?: return null
-        val primaryString = primary.format()
+        val primaryString = if (withStyle) {
+            "<strong>${primary.format()}</strong>"
+        } else {
+            primary.format()
+        }
 
         if (info.secondary.isEmpty()) return primaryString
 

--- a/library/src/commonMain/kotlin/com/gu/recipe/CookTimeUtils.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/CookTimeUtils.kt
@@ -87,6 +87,16 @@ object CookTimeUtils {
     /* PUBLIC API                    */
     /* ----------------------------- */
 
+    /**
+     * Formats a list of [Timing] entries into a human-readable cook-time display string.
+     *
+     * The primary duration is resolved by priority: prep + cook (combined) → total-time → ready-in.
+     * Passive timings (e.g. chill, marinate) are appended with " + " only when a prep/cook primary exists.
+     *
+     * @param timings the raw timing metadata from a recipe.
+     * @param withStyle when `true`, wraps the primary duration in `<strong>` tags for styled rendering.
+     * @return the formatted cook-time string, or `null` if no displayable primary timing is available.
+     */
     fun format(
         timings: List<Timing>,
         withStyle: Boolean = false,
@@ -109,6 +119,17 @@ object CookTimeUtils {
         return "$primaryString + $secondaryString"
     }
 
+    /**
+     * Builds a [CookTimeInfo] display model from raw [Timing] entries.
+     *
+     * Primary duration is resolved by combining prep + cook times when available,
+     * falling back to total-time or ready-in otherwise.
+     * Passive timings (e.g. chill, marinate) are included as secondary entries only when
+     * a prep/cook primary exists.
+     *
+     * @param timings the raw timing metadata from a recipe.
+     * @return a [CookTimeInfo] containing the combined primary duration and any secondary passive timings.
+     */
     fun structured(timings: List<Timing>): CookTimeInfo {
         val individual = structuredIndividual(timings)
         val combinedPrimary = when {

--- a/library/src/commonTest/kotlin/com/gu/recipe/CookTimeUtilsTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/CookTimeUtilsTest.kt
@@ -331,6 +331,33 @@ class CookTimeUtilsTest {
         assertEquals(0, structured.secondary.size)
     }
 
+    @Test
+    fun `format with style wraps primary in bold tags`() {
+        val input = listOf(
+            timing("prep-time", 15),
+            timing("cook-time", 45)
+        )
+
+        assertEquals("<strong>1 hr</strong>", utils.format(input, withStyle = true))
+    }
+
+    @Test
+    fun `format with style wraps only primary when passive timings present`() {
+        val input = listOf(
+            timing("prep-time", 45),
+            timing("chill-time", 30)
+        )
+
+        assertEquals("<strong>45 min</strong> + chill 30 min", utils.format(input, withStyle = true))
+    }
+
+    @Test
+    fun `format with style defaults to false`() {
+        val input = listOf(timing("prep-time", 30))
+
+        assertEquals("30 min", utils.format(input))
+    }
+
     private fun timing(
         qualifier: String,
         min: Int,


### PR DESCRIPTION
## What does this change?
The `format` method in CooktimeUtils return plain text, to support client side formatting this PR add extra style tag for the primary time information.

So when the style flag is On the output will contain a html bold tag only for the primary part, like this:
```
<strong>20 min</strong> + rest 6 hrs
```

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Unit tests
