### PR TITLE
New US units view

### DIFF
--- a/library/src/commonMain/kotlin/com/gu/recipe/FormatUtils.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/FormatUtils.kt
@@ -11,19 +11,14 @@ internal object FormatUtils {
         val fractionalPart = number - integerPart
 
         // these hard coded values are midpoints between fractions.
-        // For instance 0.1875 is halfway between 1/8 (0.125) and 1/4 (0.25)
         // This keeps the logic dead simple
         return when (fractionalPart) {
-            in 0.0f..0.062500f -> integerPartStr
-            in 0.062500f..0.187500f -> "$integerPartStr⅛"
-            in 0.187500f..0.291667f -> "$integerPartStr¼"
-            in 0.291667f..0.354167f -> "$integerPartStr⅓"
-            in 0.354167f..0.437500f -> "$integerPartStr⅜"
-            in 0.437500f..0.562500f -> "$integerPartStr½"
-            in 0.562500f..0.645833f -> "$integerPartStr⅝"
-            in 0.645833f..0.708333f -> "$integerPartStr⅔"
-            in 0.708333f..0.812500f -> "$integerPartStr¾"
-            in 0.812500f..0.937500f -> "$integerPartStr⅞"
+            in 0.0f..0.125f -> integerPartStr
+            in 0.125f..0.291667f -> "$integerPartStr¼"
+            in 0.291667f..0.416667f -> "$integerPartStr⅓"
+            in 0.416667f..0.583333f -> "$integerPartStr½"
+            in 0.583333f..0.708333f -> "$integerPartStr⅔"
+            in 0.708333f..0.875f -> "$integerPartStr¾"
             else -> "${integerPart + 1}"
         }
     }

--- a/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
@@ -70,13 +70,14 @@ class TemplateSession(private val densityTable: DensityTable) {
         amount = UnitConversions.convertUnitSystemAndScale(amount, measuringSystem, factorToUse, density)
 
         val decimals = when (amount.unit) {
-            Units.GRAM, Units.MILLILITRE, Units.MILLIMETRE -> 0
+            Units.GRAM, Units.MILLILITRE, Units.MILLIMETRE, Units.US_TEASPOON, Units.METRIC_TEASPOON, Units.US_TABLESPOON, Units.METRIC_TABLESPOON -> 0
             Units.CENTIMETRE, Units.INCH -> 1
             else -> 1
         }
 
         val fraction = when (amount.unit) {
-            Units.CENTILITRE, Units.MILLILITRE, Units.CENTIMETRE, Units.GRAM, Units.KILOGRAM, Units.MILLIMETRE -> false
+            Units.CENTILITRE, Units.MILLILITRE, Units.CENTIMETRE, Units.GRAM, Units.KILOGRAM, Units.MILLIMETRE , Units.METRIC_TEASPOON, Units.METRIC_TABLESPOON -> false
+            Units.US_TABLESPOON, Units.US_TEASPOON -> false
             else -> true
         }
         val unitString = if (amount.unit != null) {

--- a/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
@@ -110,9 +110,13 @@ class TemplateSession(private val densityTable: DensityTable) {
                         } else {
                             val cupsPart = renderQuantity(element, factor, MeasuringSystem.USCustomary)
                             val metricPart = renderQuantity(element, factor, MeasuringSystem.Metric)
-                            //NOTE - according to https://kotlinlang.org/docs/strings.html#string-formatting String.format()
-                            //only works on JVM; therefore we can't use it here
-                            metricPart + " (" + cupsPart + ")"
+                            if (cupsPart == metricPart) {
+                                cupsPart
+                            } else {
+                                //NOTE - according to https://kotlinlang.org/docs/strings.html#string-formatting String.format()
+                                //only works on JVM; therefore we can't use it here
+                                metricPart + " (" + cupsPart + ")"
+                            }
                         }
                     }
                     is MeasuringSystem.USCustomaryWithImperial -> {

--- a/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
@@ -76,8 +76,8 @@ class TemplateSession(private val densityTable: DensityTable) {
         }
 
         val fraction = when (amount.unit) {
-            Units.CENTILITRE, Units.MILLILITRE, Units.CENTIMETRE, Units.GRAM, Units.KILOGRAM, Units.MILLIMETRE , Units.METRIC_TEASPOON, Units.METRIC_TABLESPOON -> false
-            Units.US_TABLESPOON, Units.US_TEASPOON -> false
+            Units.CENTILITRE, Units.MILLILITRE, Units.CENTIMETRE, Units.GRAM, Units.KILOGRAM, Units.MILLIMETRE -> false
+            Units.METRIC_TEASPOON, Units.METRIC_TABLESPOON, Units.US_TABLESPOON, Units.US_TEASPOON -> amount.min < 1f
             else -> true
         }
         val unitString = if (amount.unit != null) {

--- a/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
@@ -134,6 +134,23 @@ class TemplateSession(private val densityTable: DensityTable) {
                             }
                         }
                     }
+                    is MeasuringSystem.USCombined -> {
+                        if(element.unit.isNullOrBlank()) {
+                            renderQuantity(element, factor, MeasuringSystem.USCustomary)
+                        } else {
+                            val cupsPart = renderQuantity(element, factor, MeasuringSystem.USCustomary)
+                            val imperialPart = renderQuantity(element, factor, MeasuringSystem.Imperial)
+                            val metricPart = renderQuantity(element, factor, MeasuringSystem.Metric)
+
+                            if (cupsPart == metricPart && cupsPart == imperialPart) {
+                                metricPart
+                            } else if (cupsPart == imperialPart) {
+                                metricPart + " (" + cupsPart + ")"
+                            } else {
+                                metricPart + " (" + imperialPart + " • " + cupsPart + ")"
+                            }
+                        }
+                    }
                 }
             }
             is OvenTemperaturePlaceholder -> renderOvenTemperature(element)

--- a/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
@@ -105,20 +105,28 @@ class TemplateSession(private val densityTable: DensityTable) {
                 when (measuringSystem) {
                     is MeasuringSystem.Metric, is MeasuringSystem.Imperial, is MeasuringSystem.USCustomary -> renderQuantity(element, factor, measuringSystem)
                     is MeasuringSystem.USCustomaryWithMetric -> {
-                        val cupsPart = renderQuantity(element, factor, MeasuringSystem.USCustomary)
-                        val metricPart = renderQuantity(element, factor, MeasuringSystem.Metric)
-                        //NOTE - according to https://kotlinlang.org/docs/strings.html#string-formatting String.format()
-                        //only works on JVM; therefore we can't use it here
-                        metricPart + " (" + cupsPart + ")"
+                        if(element.unit.isNullOrBlank()) {
+                            renderQuantity(element, factor, MeasuringSystem.USCustomary)
+                        } else {
+                            val cupsPart = renderQuantity(element, factor, MeasuringSystem.USCustomary)
+                            val metricPart = renderQuantity(element, factor, MeasuringSystem.Metric)
+                            //NOTE - according to https://kotlinlang.org/docs/strings.html#string-formatting String.format()
+                            //only works on JVM; therefore we can't use it here
+                            metricPart + " (" + cupsPart + ")"
+                        }
                     }
                     is MeasuringSystem.USCustomaryWithImperial -> {
-                        val cupsPart = renderQuantity(element, factor, MeasuringSystem.USCustomary)
-                        val imperialPart = renderQuantity(element, factor, MeasuringSystem.Imperial)
-
-                        if(cupsPart==imperialPart) {
-                            cupsPart
+                        if(element.unit.isNullOrBlank()) {
+                            renderQuantity(element, factor, MeasuringSystem.USCustomary)
                         } else {
-                            imperialPart + " (" + cupsPart + ")"
+                            val cupsPart = renderQuantity(element, factor, MeasuringSystem.USCustomary)
+                            val imperialPart = renderQuantity(element, factor, MeasuringSystem.Imperial)
+
+                            if (cupsPart == imperialPart) {
+                                cupsPart
+                            } else {
+                                imperialPart + " (" + cupsPart + ")"
+                            }
                         }
                     }
                 }

--- a/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
@@ -54,7 +54,7 @@ class TemplateSession(private val densityTable: DensityTable) {
         ).joinToString("")
     }
 
-    internal fun renderQuantity(element: QuantityPlaceholder, factor: Float, measuringSystem: MeasuringSystem): String {
+    internal fun renderQuantity(element: QuantityPlaceholder, factor: Float, measuringSystem: MeasuringSystem.MeasuringSystemInternal): String {
         var amount = Amount(
             min = element.min,
             max = if (element.min != element.max) element.max else null,
@@ -101,7 +101,28 @@ class TemplateSession(private val densityTable: DensityTable) {
     ): String {
         return when (element) {
             is TemplateConst -> element.value
-            is QuantityPlaceholder -> renderQuantity(element, factor, measuringSystem)
+            is QuantityPlaceholder -> {
+                when (measuringSystem) {
+                    is MeasuringSystem.Metric, is MeasuringSystem.Imperial, is MeasuringSystem.USCustomary -> renderQuantity(element, factor, measuringSystem)
+                    is MeasuringSystem.USCustomaryWithMetric -> {
+                        val cupsPart = renderQuantity(element, factor, MeasuringSystem.USCustomary)
+                        val metricPart = renderQuantity(element, factor, MeasuringSystem.Metric)
+                        //NOTE - according to https://kotlinlang.org/docs/strings.html#string-formatting String.format()
+                        //only works on JVM; therefore we can't use it here
+                        metricPart + " (" + cupsPart + ")"
+                    }
+                    is MeasuringSystem.USCustomaryWithImperial -> {
+                        val cupsPart = renderQuantity(element, factor, MeasuringSystem.USCustomary)
+                        val imperialPart = renderQuantity(element, factor, MeasuringSystem.Imperial)
+
+                        if(cupsPart==imperialPart) {
+                            cupsPart
+                        } else {
+                            imperialPart + " (" + cupsPart + ")"
+                        }
+                    }
+                }
+            }
             is OvenTemperaturePlaceholder -> renderOvenTemperature(element)
         }
     }

--- a/library/src/commonMain/kotlin/com/gu/recipe/unit/MeasurementUnit.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/unit/MeasurementUnit.kt
@@ -1,10 +1,16 @@
 package com.gu.recipe.unit
 
 sealed interface MeasuringSystem {
-    object Imperial : MeasuringSystem
-    object Metric : MeasuringSystem
-    object USCustomary : MeasuringSystem // will try to convert to US customary units where possible, falling back to Imperial
+    sealed interface MeasuringSystemInternal : MeasuringSystem
+
+    object Imperial : MeasuringSystemInternal
+    object Metric : MeasuringSystemInternal
+    object USCustomary: MeasuringSystemInternal
+
+    object USCustomaryWithMetric: MeasuringSystem
+    object USCustomaryWithImperial: MeasuringSystem
 }
+
 enum class UnitType {
     WEIGHT,
     VOLUME,

--- a/library/src/commonMain/kotlin/com/gu/recipe/unit/MeasurementUnit.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/unit/MeasurementUnit.kt
@@ -9,6 +9,7 @@ sealed interface MeasuringSystem {
 
     object USCustomaryWithMetric: MeasuringSystem
     object USCustomaryWithImperial: MeasuringSystem
+    object USCombined: MeasuringSystem
 }
 
 enum class UnitType {

--- a/library/src/commonMain/kotlin/com/gu/recipe/unit/UnitConversions.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/unit/UnitConversions.kt
@@ -101,7 +101,7 @@ object UnitConversions {
             MeasuringSystem.Imperial -> IMPERIAL_CONVERSION_LADDER
         }
 
-        val amountToConvert = if(amount.usCust==true && density!=null && amount.unit?.unitType== UnitType.WEIGHT) {
+        val amountToConvert = if(amount.usCust==true && target== MeasuringSystem.USCustomary && density!=null && amount.unit?.unitType== UnitType.WEIGHT) {
             //convert from g to ml. Metric -> US unit conversion is done below.
             // Assume that incoming weight here is in g (smallest unit in metric set)
             //density is in g/ml, so divide by density to go g -> ml

--- a/library/src/commonMain/kotlin/com/gu/recipe/unit/UnitConversions.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/unit/UnitConversions.kt
@@ -81,7 +81,7 @@ object UnitConversions {
         }
     }
 
-    fun convertUnitSystemAndScale(amount: Amount, target: MeasuringSystem, factor: Float = 1f, density: Float?): Amount {
+    fun convertUnitSystemAndScale(amount: Amount, target: MeasuringSystem.MeasuringSystemInternal, factor: Float = 1f, density: Float?): Amount {
         val scaledAmount = amount.copy(min = amount.min * factor, max = amount.max?.let { it * factor })
 
         if (scaledAmount.unit == null || (target == MeasuringSystem.Metric && factor == 1f)) {

--- a/library/src/commonMain/kotlin/com/gu/recipe/unit/UnitConversions.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/unit/UnitConversions.kt
@@ -49,6 +49,18 @@ object UnitConversions {
         0f to Units.INCH,
     )
 
+    val US_CUSTOMARY_DRY_CONVERSION_LADDER = listOf<Pair<Float, MeasurementUnit>>(
+        0f to Units.OUNCE,
+        16f * Units.OUNCE.quantity to Units.POUND,
+
+        0f to Units.US_TEASPOON,
+        3f * Units.US_TEASPOON.quantity to Units.US_TABLESPOON,
+        12f * Units.US_TEASPOON.quantity to Units.US_CUP,
+
+        0f to Units.INCH,
+    )
+
+
     val IMPERIAL_CONVERSION_LADDER = listOf<Pair<Float, MeasurementUnit>>(
         0f to Units.OUNCE,
         16f * Units.OUNCE.quantity to Units.POUND,
@@ -96,7 +108,10 @@ object UnitConversions {
             else
                 METRIC_CONVERSION_LADDER
 
-            MeasuringSystem.USCustomary -> US_CUSTOMARY_CONVERSION_LADDER
+            MeasuringSystem.USCustomary -> if(amount.usCust==true && amount.unit?.unitType==UnitType.WEIGHT)
+                US_CUSTOMARY_DRY_CONVERSION_LADDER
+            else
+                US_CUSTOMARY_CONVERSION_LADDER
 
             MeasuringSystem.Imperial -> IMPERIAL_CONVERSION_LADDER
         }

--- a/library/src/commonTest/kotlin/com/gu/recipe/FormatUtilsTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/FormatUtilsTest.kt
@@ -55,7 +55,6 @@ class FormatUtilsTest {
         assertEquals("1½", formatAmount(1.52f, 2, true))
         assertEquals("2¼", formatAmount(2.26f, 2, true))
         assertEquals("2⅔", formatAmount(2.67f, 2, true))
-        assertEquals("7⅛", formatAmount(7.13f, 2, true))
         assertEquals("8", formatAmount(8.01f, 2, true))
         assertEquals("8", formatAmount(7.99f, 2, true))
     }

--- a/library/src/commonTest/kotlin/com/gu/recipe/RenderTemplateTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/RenderTemplateTest.kt
@@ -58,20 +58,21 @@ class RenderTemplateTest {
         assertEquals("1 tbsp", result)
     }
 
-    @Test
-    fun `scale template with fraction for tsp`() {
-        val template = ParsedTemplate(
-            listOf(
-                QuantityPlaceholder(
-                    min = 0.25f,
-                    unit = "tsp",
-                    scale = true
-                )
-            )
-        )
-        val result = session.renderTemplate(template, 2f, MeasuringSystem.Metric)
-        assertEquals("½ tsp", result)
-    }
+    //Dropped fractional teaspoons - pending editorial confirmation on <1 tsp measurement
+//    @Test
+//    fun `scale template with fraction for tsp`() {
+//        val template = ParsedTemplate(
+//            listOf(
+//                QuantityPlaceholder(
+//                    min = 0.25f,
+//                    unit = "tsp",
+//                    scale = true
+//                )
+//            )
+//        )
+//        val result = session.renderTemplate(template, 2f, MeasuringSystem.Metric)
+//        assertEquals("½ tsp", result)
+//    }
 
     @Test
     fun `scale template with fraction for cups`() {

--- a/library/src/commonTest/kotlin/com/gu/recipe/RenderTemplateTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/RenderTemplateTest.kt
@@ -589,6 +589,23 @@ class RenderTemplateTest {
     }
 
     @Test
+    fun `render more than 6 tbsp as cups`() {
+        val template = ParsedTemplate(
+            listOf(
+                QuantityPlaceholder(
+                    min = 9f,
+                    max = 9f,
+                    unit = "tbsp",
+                    scale = true,
+                    usCust = true
+                ),
+                TemplateConst(" of oil"),
+            )
+        )
+        val result = session.renderTemplate(template, 1f, MeasuringSystem.USCombined)
+        assertEquals("9 tbsp (4½ fl oz • ½ cup) of oil", result)
+    }
+    @Test
     fun `correctly show weight measurements in metric + cups`() {
         val template = ParsedTemplate(
             listOf(

--- a/library/src/commonTest/kotlin/com/gu/recipe/RenderTemplateTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/RenderTemplateTest.kt
@@ -460,5 +460,89 @@ class RenderTemplateTest {
         val result = session.renderTemplate(template, 1f, MeasuringSystem.Metric)
         assertEquals("Use “00” flour and you’ll get – I think – the best results.", result)
     }
+
+    @Test
+    fun `render hybrid metric + cups when requested`() {
+        val template = ParsedTemplate(
+            listOf(
+                QuantityPlaceholder(
+                    min = 100f,
+                    unit = "ml",
+                    scale = true,
+                    usCust = true
+                ),
+                TemplateConst(" of water, "),
+                QuantityPlaceholder(
+                    min = 120f,
+                    unit = "ml",
+                    scale = true,
+                    usCust = true
+                ),
+                TemplateConst(" of oil"),
+            )
+        )
+        val result = session.renderTemplate(template, 1f, MeasuringSystem.USCustomaryWithMetric)
+        assertEquals("100 ml (⅜ cup) of water, 120 ml (½ cup) of oil", result)
+    }
+
+    @Test
+    fun `render hybrid imperial + cups when requested`() {
+        val template = ParsedTemplate(
+            listOf(
+                QuantityPlaceholder(
+                    min = 100f,
+                    unit = "ml",
+                    scale = true,
+                    usCust = true
+                ),
+                TemplateConst(" of water, "),
+                QuantityPlaceholder(
+                    min = 120f,
+                    unit = "ml",
+                    scale = true,
+                    usCust = true
+                ),
+                TemplateConst(" of oil"),
+            )
+        )
+        val result = session.renderTemplate(template, 1f, MeasuringSystem.USCustomaryWithImperial)
+        assertEquals("3⅜ fl oz (⅜ cup) of water, 4 fl oz (½ cup) of oil", result)
+    }
+
+    @Test
+    fun `not duplicate weight measurements in imperial + cups`() {
+        val template = ParsedTemplate(
+            listOf(
+                QuantityPlaceholder(
+                    min = 100f,
+                    max = 100f,
+                    unit = "g",
+                    scale = true,
+                    usCust = false
+                ),
+                TemplateConst(" of vegan pork"),
+            )
+        )
+        val result = session.renderTemplate(template, 1f, MeasuringSystem.USCustomaryWithImperial)
+        assertEquals("3½ oz of vegan pork", result)
+    }
+
+    @Test
+    fun `correctly show weight measurements in metric + cups`() {
+        val template = ParsedTemplate(
+            listOf(
+                QuantityPlaceholder(
+                    min = 100f,
+                    max = 100f,
+                    unit = "g",
+                    scale = true,
+                    usCust = false
+                ),
+                TemplateConst(" of vegan pork"),
+            )
+        )
+        val result = session.renderTemplate(template, 1f, MeasuringSystem.USCustomaryWithMetric)
+        assertEquals("100 g (3½ oz) of vegan pork", result)
+    }
 }
 

--- a/library/src/commonTest/kotlin/com/gu/recipe/RenderTemplateTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/RenderTemplateTest.kt
@@ -487,6 +487,30 @@ class RenderTemplateTest {
     }
 
     @Test
+    fun `render hybrid metric + imperial + cups when requested`() {
+        val template = ParsedTemplate(
+            listOf(
+                QuantityPlaceholder(
+                    min = 100f,
+                    unit = "ml",
+                    scale = true,
+                    usCust = true
+                ),
+                TemplateConst(" of water, "),
+                QuantityPlaceholder(
+                    min = 120f,
+                    unit = "ml",
+                    scale = true,
+                    usCust = true
+                ),
+                TemplateConst(" of oil"),
+            )
+        )
+        val result = session.renderTemplate(template, 1f, MeasuringSystem.USCombined)
+        assertEquals("100 ml (3⅓ fl oz • ½ cup) of water, 120 ml (4 fl oz • ½ cup) of oil", result)
+    }
+
+    @Test
     fun `render hybrid imperial + cups when requested`() {
         val template = ParsedTemplate(
             listOf(
@@ -526,6 +550,42 @@ class RenderTemplateTest {
         )
         val result = session.renderTemplate(template, 1f, MeasuringSystem.USCustomaryWithImperial)
         assertEquals("3½ oz of vegan pork", result)
+    }
+
+    @Test
+    fun `not duplicate weight measurements in imperial + cups + metric`() {
+        val template = ParsedTemplate(
+            listOf(
+                QuantityPlaceholder(
+                    min = 100f,
+                    max = 100f,
+                    unit = "g",
+                    scale = true,
+                    usCust = false
+                ),
+                TemplateConst(" of vegan pork"),
+            )
+        )
+        val result = session.renderTemplate(template, 1f, MeasuringSystem.USCombined)
+        assertEquals("100 g (3½ oz) of vegan pork", result)
+    }
+
+    @Test
+    fun `not duplicate non-standard units in imperial + cups + metric`() {
+        val template = ParsedTemplate(
+            listOf(
+                QuantityPlaceholder(
+                    min = 5f,
+                    max = 5f,
+                    unit = "pinches",
+                    scale = true,
+                    usCust = false
+                ),
+                TemplateConst(" of gunpowder"),
+            )
+        )
+        val result = session.renderTemplate(template, 1f, MeasuringSystem.USCombined)
+        assertEquals("5 pinches of gunpowder", result)
     }
 
     @Test

--- a/library/src/commonTest/kotlin/com/gu/recipe/RenderTemplateTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/RenderTemplateTest.kt
@@ -58,21 +58,20 @@ class RenderTemplateTest {
         assertEquals("1 tbsp", result)
     }
 
-    //Dropped fractional teaspoons - pending editorial confirmation on <1 tsp measurement
-//    @Test
-//    fun `scale template with fraction for tsp`() {
-//        val template = ParsedTemplate(
-//            listOf(
-//                QuantityPlaceholder(
-//                    min = 0.25f,
-//                    unit = "tsp",
-//                    scale = true
-//                )
-//            )
-//        )
-//        val result = session.renderTemplate(template, 2f, MeasuringSystem.Metric)
-//        assertEquals("½ tsp", result)
-//    }
+    @Test
+    fun `scale template with fraction for tsp`() {
+        val template = ParsedTemplate(
+            listOf(
+                QuantityPlaceholder(
+                    min = 0.25f,
+                    unit = "tsp",
+                    scale = true
+                )
+            )
+        )
+        val result = session.renderTemplate(template, 2f, MeasuringSystem.Metric)
+        assertEquals("½ tsp", result)
+    }
 
     @Test
     fun `scale template with fraction for cups`() {

--- a/library/src/commonTest/kotlin/com/gu/recipe/RenderTemplateTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/RenderTemplateTest.kt
@@ -133,7 +133,7 @@ class RenderTemplateTest {
             )
         )
         val result = session.renderTemplate(template, 1.0f, MeasuringSystem.USCustomary)
-        assertEquals("8⅞ oz", result)
+        assertEquals("8¾ oz", result)
     }
 
     @Test
@@ -151,7 +151,7 @@ class RenderTemplateTest {
             )
         )
         val result = session.renderTemplate(template, 1.0f, MeasuringSystem.USCustomary)
-        assertEquals("1⅓-3⅛ cups", result)
+        assertEquals("1⅓-3¼ cups", result)
     }
 
     @Test
@@ -168,7 +168,7 @@ class RenderTemplateTest {
             )
         )
         val result = session.renderTemplate(template, 2.0f, MeasuringSystem.USCustomary)
-        assertEquals("2⅛ cups", result) //extra 1/8 due to rounding
+        assertEquals("2 cups", result) //extra 1/8 due to rounding
     }
 
     @Test
@@ -447,7 +447,7 @@ class RenderTemplateTest {
             )
         )
         val result = session.renderTemplate(template, 1f, MeasuringSystem.USCustomary)
-        assertEquals("⅜ cup of water, ½ cup of oil", result)
+        assertEquals("½ cup of water, ½ cup of oil", result)
     }
 
     @Test
@@ -482,7 +482,7 @@ class RenderTemplateTest {
             )
         )
         val result = session.renderTemplate(template, 1f, MeasuringSystem.USCustomaryWithMetric)
-        assertEquals("100 ml (⅜ cup) of water, 120 ml (½ cup) of oil", result)
+        assertEquals("100 ml (½ cup) of water, 120 ml (½ cup) of oil", result)
     }
 
     @Test
@@ -506,7 +506,7 @@ class RenderTemplateTest {
             )
         )
         val result = session.renderTemplate(template, 1f, MeasuringSystem.USCustomaryWithImperial)
-        assertEquals("3⅜ fl oz (⅜ cup) of water, 4 fl oz (½ cup) of oil", result)
+        assertEquals("3⅓ fl oz (½ cup) of water, 4 fl oz (½ cup) of oil", result)
     }
 
     @Test

--- a/library/src/commonTest/kotlin/com/gu/recipe/ScaleRecipeTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/ScaleRecipeTest.kt
@@ -58,7 +58,7 @@ class ScaleRecipeTest {
                         ),
                         IngredientItem(
                             template = """{"min": 0.25, "unit": "tbsp", "scale": true} of salt""",
-                            text = "<strong>1½ tsp of salt</strong>"
+                            text = "<strong>2 tsp of salt</strong>"
                         ),
                         IngredientItem(
                             template = """{"min":1, "scale":true} x {"min":400, "unit":"g", "scale":false} tin chopped tomatoes""",

--- a/library/src/jsMain/kotlin/com/gu/recipe/js/ScaleRecipeJsContract.kt
+++ b/library/src/jsMain/kotlin/com/gu/recipe/js/ScaleRecipeJsContract.kt
@@ -24,6 +24,7 @@ fun scaleRecipe(recipe: String, factor: Float, unit: String, session: TemplateSe
         "US" -> MeasuringSystem.USCustomary
         "USWithMetric" -> MeasuringSystem.USCustomaryWithMetric
         "USWithImperial" -> MeasuringSystem.USCustomaryWithImperial
+        "Combined" -> MeasuringSystem.USCombined
         else -> throw IllegalArgumentException("Unknown unit: $unit")
     }
     val scaledRecipe = session.scaleAndConvertUnitRecipe(parsedRecipe, factor, measuringSystem)

--- a/library/src/jsMain/kotlin/com/gu/recipe/js/ScaleRecipeJsContract.kt
+++ b/library/src/jsMain/kotlin/com/gu/recipe/js/ScaleRecipeJsContract.kt
@@ -22,6 +22,8 @@ fun scaleRecipe(recipe: String, factor: Float, unit: String, session: TemplateSe
         "Imperial" -> MeasuringSystem.Imperial
         "Metric" -> MeasuringSystem.Metric
         "US" -> MeasuringSystem.USCustomary
+        "USWithMetric" -> MeasuringSystem.USCustomaryWithMetric
+        "USWithImperial" -> MeasuringSystem.USCustomaryWithImperial
         else -> throw IllegalArgumentException("Unknown unit: $unit")
     }
     val scaledRecipe = session.scaleAndConvertUnitRecipe(parsedRecipe, factor, measuringSystem)


### PR DESCRIPTION
## What does this change?

1. Adds another possible rendering mode - `MeasuringSystem.Combined`.  This will display Metric, US Imperial and cups alongside each other:
<img width="489" height="573" alt="Screenshot 2026-03-04 at 16 00 25" src="https://github.com/user-attachments/assets/50b94a3f-1adb-417f-bb36-444913b02430" />

2. Removes eighth fractions as these are considered too fiddly.  Smallest fraction is now 1/4.
3. Adjusts the tbsp/cup threshold so anything > 6 tbsp is rendered as a fraction of a cup
4. Removes fractions from measurements of tsp and tbsp as these are considered fiddly

### Notes

The `MeasuringSystem` enum is now split to `MeasuringSystemInternal` and `MeasuringSystem`.  This is because the "combined" renderers use multiple measuring systems internally; `MeasuringSystemInternal` is a _sub-set_ of `MeasuringSystem` which represents the individual rather than _combined_ measuring systems.  There is no change to the externally facing API as a result of this; clients will just see more options for MeasuringSystem.

## How to test

- Build the library
- Update your app
- Change the "US" selector to map to `MeasuringSystem.Combined` instead of `MeasuringSystem.USCustomary`
- Browse some recipes. When in "US" mode they should look similar to the screenshots above.
- There are lists of currently convertible recipes in Asana at https://app.asana.com/1/1210045093164357/project/1212689947856885/task/1213296996244077; however this assumes you are using the latest density data from the CDN

## How can we measure success?

Able to progress to the next stage of review, within the app

## Have we considered potential risks?

n/a, this is all behind a switch at the moment
