### PR TITLE
Updates for US preview in Composer

### DIFF
--- a/library/src/jsMain/kotlin/com/gu/recipe/js/ScaleRecipeJsContract.kt
+++ b/library/src/jsMain/kotlin/com/gu/recipe/js/ScaleRecipeJsContract.kt
@@ -42,9 +42,18 @@ fun parseTemplate(templateString: String): List<TemplateElement> {
 
 @OptIn(ExperimentalJsExport::class)
 @JsExport
-fun renderTemplate(templateElements: List<TemplateElement>, session: TemplateSession): String {
+fun renderTemplate(templateElements: List<TemplateElement>, session: TemplateSession, unit: String): String {
+    val measuringSystem = when (unit) {
+        "Imperial" -> MeasuringSystem.Imperial
+        "Metric" -> MeasuringSystem.Metric
+        "US" -> MeasuringSystem.USCustomary
+        "USWithMetric" -> MeasuringSystem.USCustomaryWithMetric
+        "USWithImperial" -> MeasuringSystem.USCustomaryWithImperial
+        "Combined" -> MeasuringSystem.USCombined
+        else -> throw IllegalArgumentException("Unknown unit: $unit")
+    }
     val template = ParsedTemplate(templateElements)
-    return session.renderTemplate(template, 1.0f, MeasuringSystem.Metric)
+    return session.renderTemplate(template, 1.0f, measuringSystem)
 }
 
 @OptIn(ExperimentalJsExport::class)


### PR DESCRIPTION
## What does this change?

- Adds a "unit" parameter to `renderTemplate` in JS so we can do US preview in Composer

## How to test

This is a prerequisite for https://github.com/guardian/flexible-content/tree/ag/feast-us-units-preview to be able to work.  Build locally and run against that branch of Composer to test.

There should be no changes for iOS or Android.

## How can we measure success?

Able to proceed with Composer updates

## Have we considered potential risks?

n/a
