### PR TITLE
Revised cooktime logic

### DIFF
--- a/library/src/commonMain/kotlin/com/gu/recipe/CookTimeUtils.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/CookTimeUtils.kt
@@ -13,8 +13,8 @@ import kotlin.math.roundToInt
  * - otherwise ready-in,
  * - otherwise no display.
  *
- * Output uses fixed `hr`/`min` units (never pluralised) and `days` (always plural, since threshold ≥ 4).
- * Durations ≥ 5760 min (4 days / 96 hr) are converted to the `day` unit with
+ * Output uses fixed `hr`/`min` units (never pluralised) and `days` (always plural, since day-based formatting only starts above 4 days).
+ * Durations > 5760 min (more than 4 days / 96 hr) are converted to the `day` unit with
  * Unicode fractions (¼ ½ ¾) for quarter-day remainders.
  *
  * When min ≠ max, durations are formatted as ranges: `"20 - 30 min"`.

--- a/library/src/commonMain/kotlin/com/gu/recipe/CookTimeUtils.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/CookTimeUtils.kt
@@ -30,7 +30,7 @@ object CookTimeUtils {
     private const val MINUTES_PER_HOUR = 60
     private const val MINUTES_PER_DAY = 1440
     private const val MINUTES_PER_QUARTER_DAY = 360
-    // 4 days (96 hr) — threshold above which output switches to the "day" unit.
+    // 4 days (96 hr) — output switches to the "days" unit only above this value (exclusive).
     private const val DAY_THRESHOLD = 5760
     private val PRIMARY_QUALIFIERS = setOf("prep-time", "cook-time", "prep", "cook")
     private val PREP_QUALIFIERS = setOf("prep-time", "prep")
@@ -233,7 +233,7 @@ object CookTimeUtils {
      * Used by [CookDurationRange.format] to decide whether a range can be consolidated.
      */
     private fun unitOf(minutes: Int): String? = when {
-        minutes >= DAY_THRESHOLD && isDayFormattable(minutes) -> "days"
+        minutes > DAY_THRESHOLD && isDayFormattable(minutes) -> "days"
         minutes < MINUTES_PER_HOUR -> "min"
         minutes % MINUTES_PER_HOUR == 0 -> "hr"
         else -> null // compound "N hr M min"
@@ -247,12 +247,12 @@ object CookTimeUtils {
 
     /**
      * Formats a minute value into `hr`/`min`/`day` text.
-     * ≥ [DAY_THRESHOLD] (5760 min / 96 hr / 4 days) → day unit.
+     * > [DAY_THRESHOLD] (5760 min / 96 hr / 4 days) → days unit.
      * ≥ 60 min → hr/min unit.
      * Otherwise → min unit.
      */
     private fun formatMinutes(minutes: Int): String {
-        if (minutes >= DAY_THRESHOLD) {
+        if (minutes > DAY_THRESHOLD) {
             val days = minutes / MINUTES_PER_DAY
             val remainder = minutes % MINUTES_PER_DAY
             if (remainder == 0) return "$days days"

--- a/library/src/commonMain/kotlin/com/gu/recipe/CookTimeUtils.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/CookTimeUtils.kt
@@ -58,12 +58,12 @@ object CookTimeUtils {
             if (isFixed) return formatMinutes(minMinutes)
             val minText = formatMinutes(minMinutes)
             val maxText = formatMinutes(maxMinutes)
-            // When both ends are a simple "<number> <unit>" with the same unit,
-            // consolidate into "<min> - <max> <unit>" (e.g. "20 - 30 min").
-            val minParts = minText.split(' ')
-            val maxParts = maxText.split(' ')
-            if (minParts.size == 2 && maxParts.size == 2 && minParts[1] == maxParts[1]) {
-                return "${minParts[0]} - $maxText"
+            // When both ends resolve to the same simple unit, strip the unit from the
+            // first value so the range reads e.g. "20 - 30 min" instead of "20 min - 30 min".
+            val minUnit = unitOf(minMinutes)
+            val maxUnit = unitOf(maxMinutes)
+            if (minUnit != null && minUnit == maxUnit) {
+                return "${minText.removeSuffix(" $minUnit").trimEnd()} - $maxText"
             }
             return "$minText - $maxText"
         }
@@ -225,6 +225,24 @@ object CookTimeUtils {
         }
         // Qualifiers may omit the "-time" suffix (e.g. "ferment"), so treat any unknown qualifier as passive.
         return removeSuffix("-time").lowercase()
+    }
+
+    /**
+     * Returns the single display unit a minute value would format into,
+     * or `null` when the output is compound (e.g. "1 hr 30 min").
+     * Used by [CookDurationRange.format] to decide whether a range can be consolidated.
+     */
+    private fun unitOf(minutes: Int): String? = when {
+        minutes >= DAY_THRESHOLD && isDayFormattable(minutes) -> "days"
+        minutes < MINUTES_PER_HOUR -> "min"
+        minutes % MINUTES_PER_HOUR == 0 -> "hr"
+        else -> null // compound "N hr M min"
+    }
+
+    /** `true` when the value formats as whole or fractional days (not hr/min fallback). */
+    private fun isDayFormattable(minutes: Int): Boolean {
+        val remainder = minutes % MINUTES_PER_DAY
+        return remainder == 0 || remainder.toQuarterDayFraction() != null
     }
 
     /**

--- a/library/src/commonMain/kotlin/com/gu/recipe/CookTimeUtils.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/CookTimeUtils.kt
@@ -13,29 +13,29 @@ import kotlin.math.roundToInt
  * - otherwise ready-in,
  * - otherwise no display.
  *
- * Passive timings are appended with " + " only when a prep/cook primary exists.
- * Output uses fixed `hr`/`min` units and supports Unicode day fractions for passive quarter-day values.
+ * Output uses fixed `hr`/`min` units (never pluralised) and `days` (always plural, since threshold ≥ 4).
+ * Durations ≥ 5760 min (4 days / 96 hr) are converted to the `day` unit with
+ * Unicode fractions (¼ ½ ¾) for quarter-day remainders.
  *
- * `structured()` returns the display model with combined primary timing.
+ * When min ≠ max, durations are formatted as ranges: `"20 - 30 min"`.
+ *
+ * Two display modes:
+ * - `format()` — concatenated: primary duration + passive labels only (no passive values).
+ * - `formatToItems()` — individually formatted: each entry with full label and duration (including ranges and day fractions).
+ *
+ * `structured()` returns the combined display model.
  * `structuredIndividual()` returns individual prep/cook entries without combining.
  */
 object CookTimeUtils {
     private const val MINUTES_PER_HOUR = 60
     private const val MINUTES_PER_DAY = 1440
     private const val MINUTES_PER_QUARTER_DAY = 360
+    // 4 days (96 hr) — threshold above which output switches to the "day" unit.
+    private const val DAY_THRESHOLD = 5760
     private val PRIMARY_QUALIFIERS = setOf("prep-time", "cook-time", "prep", "cook")
+    private val PREP_QUALIFIERS = setOf("prep-time", "prep")
     private val TOTAL_QUALIFIERS = setOf("total-time")
     private val READY_IN_QUALIFIERS = setOf("ready-in", "ready-in-time")
-    private val PASSIVE_LABELS = mapOf(
-        "chill-time" to "chill",
-        "marinate-time" to "marinate",
-        "freeze-time" to "freeze",
-        "prove-time" to "prove",
-        "rest-time" to "rest",
-        "soak-time" to "soak",
-        "set-time" to "set",
-        "cool-time" to "cool"
-    )
 
     /* ----------------------------- */
     /* DOMAIN TYPES                  */
@@ -44,15 +44,28 @@ object CookTimeUtils {
     private data class ParsedTiming(
         val qualifier: String,
         val passiveLabel: String?,
-        val minutes: Int
+        val duration: CookDurationRange
     )
 
-    data class CookDuration(val minutes: Int) {
+    /**
+     * A duration that may represent a range (min–max) or a fixed value (min == max).
+     */
+    data class CookDurationRange(val minMinutes: Int, val maxMinutes: Int) {
+        /** `true` when the duration represents an exact value, not a range. */
+        val isFixed: Boolean get() = minMinutes == maxMinutes
+
         fun format(): String {
-            if (minutes < MINUTES_PER_HOUR) return "$minutes min"
-            val hours = minutes / MINUTES_PER_HOUR
-            val remainder = minutes % MINUTES_PER_HOUR
-            return if (remainder == 0) "$hours hr" else "$hours hr $remainder min"
+            if (isFixed) return formatMinutes(minMinutes)
+            val minText = formatMinutes(minMinutes)
+            val maxText = formatMinutes(maxMinutes)
+            // When both ends are a simple "<number> <unit>" with the same unit,
+            // consolidate into "<min> - <max> <unit>" (e.g. "20 - 30 min").
+            val minParts = minText.split(' ')
+            val maxParts = maxText.split(' ')
+            if (minParts.size == 2 && maxParts.size == 2 && minParts[1] == maxParts[1]) {
+                return "${minParts[0]} - $maxText"
+            }
+            return "$minText - $maxText"
         }
     }
 
@@ -60,27 +73,34 @@ object CookTimeUtils {
      * Combined display model containing primary cook time and passive secondary timings.
      */
     data class CookTimeInfo(
-        val primary: CookDuration?,
-        val secondary: List<Pair<String, CookDuration>>
+        val primary: CookDurationRange?,
+        val secondary: List<Pair<String, CookDurationRange>>
     )
 
     /**
-     * A labeled [CookDuration] entry used for a single timing.
+     * A labeled [CookDurationRange] entry used for a single timing.
      */
     data class LabeledCookDuration(
         val label: String,
-        val duration: CookDuration
-    )
+        val duration: CookDurationRange,
+        val isPassive: Boolean = false
+    ) {
+        /** Label with first character uppercased, e.g. "prep" → "Prep". */
+        val capitalizedLabel: String get() = label.replaceFirstChar { it.uppercaseChar() }
+    }
 
     /**
      * Uncombined timing model with primary entries, fallback entry, and passive entries.
      * Useful when apps need to render individual timing entries while preserving formatter output (i.e. in recipe
      * page).
+     *
+     * [all] contains primary and secondary entries in the original input order.
      */
     data class StructuredIndividualInfo(
         val primary: List<LabeledCookDuration>,
         val fallback: LabeledCookDuration?,
-        val secondary: List<LabeledCookDuration>
+        val secondary: List<LabeledCookDuration>,
+        val all: List<LabeledCookDuration> = emptyList()
     )
 
     /* ----------------------------- */
@@ -88,9 +108,10 @@ object CookTimeUtils {
     /* ----------------------------- */
 
     /**
-     * Formats a list of [Timing] entries into a human-readable cook-time display string.
+     * Formats a list of [Timing] entries into a human-readable cook-time display string (concatenated mode).
      *
      * The primary duration is resolved by priority: prep + cook (combined) → total-time → ready-in.
+     * When min ≠ max, the primary is formatted as a range (e.g. `"20 - 30 min"`).
      * Passive timings (e.g. chill, marinate) are appended as label-only with " + " when a prep/cook primary exists.
      *
      * @param timings the raw timing metadata from a recipe.
@@ -104,21 +125,22 @@ object CookTimeUtils {
 
         if (info.secondary.isEmpty()) return primaryString
 
-        val secondaryString = info.secondary.joinToString(" + ") { it.first }
-
-        return "$primaryString + $secondaryString"
+        return "$primaryString + ${info.secondary.joinToString(" + ") { it.first }}"
     }
 
     /**
-     * Formats a list of [Timing] entries into individual timing items, each represented as a map.
+     * Formats a list of [Timing] entries into individual timing items, each represented as a map
+     * (individually formatted mode).
      *
-     * Each timing entry is kept separate (prep, cook, passive) rather than being combined. The returned list contains
-     * primary entries first, followed by secondary (passive) entries when a prep/cook primary exists. When only a
-     * total-time or ready-in fallback is available, only the fallback entry is returned and passive timings are
-     * omitted.
+     * Each timing entry is kept separate (prep, cook, passive) rather than being combined.
+     * The original ordering of the input timings is preserved.
+     * When only a total-time or ready-in fallback is available, only the fallback entry is
+     * returned and passive timings are omitted.
      *
      * Each map is a single entry where the key is the capitalised label and the value
      * is the formatted duration, e.g. `mapOf("Prep" to "20 min")`.
+     * Ranges are formatted as `"20 - 30 min"`.
+     * Durations ≥ 4 days use fractional-day notation (e.g. `"4½ days"`).
      *
      * @param timings the raw timing metadata from a recipe.
      * @return a list of single-entry maps, or an empty list if no displayable timings are available.
@@ -129,15 +151,12 @@ object CookTimeUtils {
         val items = mutableListOf<Map<String, String>>()
 
         if (individual.primary.isNotEmpty()) {
-            individual.primary.forEach {
-                items.add(mapOf(it.label.replaceFirstChar { c -> c.uppercaseChar() } to it.duration.format()))
+            // Walk all entries in original order, emitting primary and secondary items.
+            individual.all.forEach { entry ->
+                items.add(mapOf(entry.capitalizedLabel to entry.duration.format()))
             }
         } else if (individual.fallback != null) {
-            items.add(mapOf(individual.fallback.label.replaceFirstChar { it.uppercaseChar() } to individual.fallback.duration.format()))
-        }
-
-        individual.secondary.forEach {
-            items.add(mapOf(it.label.replaceFirstChar { c -> c.uppercaseChar() } to formatPassiveDuration(it.duration.minutes)))
+            items.add(mapOf(individual.fallback.capitalizedLabel to individual.fallback.duration.format()))
         }
 
         return items
@@ -148,6 +167,7 @@ object CookTimeUtils {
      *
      * Primary duration is resolved by combining prep + cook times when available,
      * falling back to total-time or ready-in otherwise.
+     * When combining, min values are summed and max values are summed independently to preserve range semantics.
      * Passive timings (e.g. chill, marinate) are included as secondary entries only when
      * a prep/cook primary exists.
      *
@@ -156,8 +176,11 @@ object CookTimeUtils {
      */
     fun structured(timings: List<Timing>): CookTimeInfo {
         val individual = structuredIndividual(timings)
-        val combinedPrimary = when {
-            individual.primary.isNotEmpty() -> CookDuration(individual.primary.sumOf { it.duration.minutes })
+        val combinedPrimary: CookDurationRange? = when {
+            individual.primary.isNotEmpty() -> CookDurationRange(
+                minMinutes = individual.primary.sumOf { it.duration.minMinutes },
+                maxMinutes = individual.primary.sumOf { it.duration.maxMinutes }
+            )
             individual.fallback != null -> individual.fallback.duration
             else -> null
         }
@@ -173,27 +196,26 @@ object CookTimeUtils {
     /* MAPPING                       */
     /* ----------------------------- */
 
-    private fun Range.toCookDuration(): CookDuration? {
-        // Source may contain ranges; display uses a single value, so we prioritise min.
-        val minutes = (min ?: max)?.toRoundedMinutes() ?: return null
-        if (minutes <= 0) return null
-        return CookDuration(minutes)
+    private fun Range.toCookDurationRange(): CookDurationRange? {
+        val minVal = (min ?: max)?.roundToInt() ?: return null
+        val maxVal = (max ?: min)?.roundToInt() ?: return null
+        if (minVal <= 0 && maxVal <= 0) return null
+        // Normalise so minMinutes is always ≤ maxMinutes regardless of source ordering.
+        return CookDurationRange(minMinutes = minOf(minVal, maxVal), maxMinutes = maxOf(minVal, maxVal))
     }
 
-    private fun Double.toRoundedMinutes(): Int = roundToInt()
-
     private fun Timing.toParsedTiming(): ParsedTiming? {
-        val duration = durationInMins?.toCookDuration() ?: return null
+        val duration = durationInMins?.toCookDurationRange() ?: return null
         val qualifierValue = qualifier ?: return null
         val isPrimary = qualifierValue in PRIMARY_QUALIFIERS
         val isFallback = qualifierValue in TOTAL_QUALIFIERS || qualifierValue in READY_IN_QUALIFIERS
-        val passiveLabel = PASSIVE_LABELS[qualifierValue] ?: qualifierValue.toPassiveLabelOrNull()
+        val passiveLabel = qualifierValue.toPassiveLabelOrNull()
         if (!isPrimary && !isFallback && passiveLabel == null) return null
 
         return ParsedTiming(
             qualifier = qualifierValue,
             passiveLabel = passiveLabel,
-            minutes = duration.minutes
+            duration = duration
         )
     }
 
@@ -205,59 +227,88 @@ object CookTimeUtils {
         return removeSuffix("-time").lowercase()
     }
 
-    private fun formatPassiveDuration(minutes: Int): String {
-        // Spec requires Unicode vulgar fractions when passive durations are represented in days.
-        val fractionText = minutes.toFractionalDayTextOrNull()
-        return fractionText ?: CookDuration(minutes).format()
+    /**
+     * Formats a minute value into `hr`/`min`/`day` text.
+     * ≥ [DAY_THRESHOLD] (5760 min / 96 hr / 4 days) → day unit.
+     * ≥ 60 min → hr/min unit.
+     * Otherwise → min unit.
+     */
+    private fun formatMinutes(minutes: Int): String {
+        if (minutes >= DAY_THRESHOLD) {
+            val days = minutes / MINUTES_PER_DAY
+            val remainder = minutes % MINUTES_PER_DAY
+            if (remainder == 0) return "$days days"
+            val fraction = remainder.toQuarterDayFraction()
+            if (fraction != null) return "$days$fraction days"
+            // Non-quarter-day remainder — fall through to hr/min formatting below.
+        }
+        if (minutes < MINUTES_PER_HOUR) return "$minutes min"
+        val hours = minutes / MINUTES_PER_HOUR
+        val remainder = minutes % MINUTES_PER_HOUR
+        return if (remainder == 0) "$hours hr" else "$hours hr $remainder min"
     }
 
-    private fun Int.toFractionalDayTextOrNull(): String? {
-        if (this !in 1..<MINUTES_PER_DAY) return null
+    private fun Int.toQuarterDayFraction(): String? {
         if (this % MINUTES_PER_QUARTER_DAY != 0) return null
-
         return when (this / MINUTES_PER_QUARTER_DAY) {
-            1 -> "¼ day"
-            2 -> "½ day"
-            3 -> "¾ day"
+            1 -> "¼"
+            2 -> "½"
+            3 -> "¾"
             else -> null
         }
     }
 
+
     fun structuredIndividual(timings: List<Timing>): StructuredIndividualInfo {
         val mapped = timings.mapNotNull { it.toParsedTiming() }
+        val hasPrimary = mapped.any { it.qualifier in PRIMARY_QUALIFIERS }
 
-        val primary = mapped
-            .filter { it.qualifier in PRIMARY_QUALIFIERS }
-            .map { timing ->
-                val label = if (timing.qualifier == "prep-time" || timing.qualifier == "prep") "prep" else "cook"
-                LabeledCookDuration(label = label, duration = CookDuration(timing.minutes))
-            }
+        // Build the ordered list of all displayable entries, tagging each as primary or passive.
+        val all = if (hasPrimary) {
+            mapped.mapNotNull { it.toLabeledCookDuration() }
+        } else {
+            emptyList()
+        }
 
-        val fallback = if (primary.isEmpty()) {
+        val primary = all.filter { !it.isPassive }
+
+        val fallback = if (!hasPrimary) {
             val fallbackTiming = mapped.firstOrNull { it.qualifier in TOTAL_QUALIFIERS }
                 ?: mapped.firstOrNull { it.qualifier in READY_IN_QUALIFIERS }
             fallbackTiming?.let {
                 val label = if (it.qualifier in TOTAL_QUALIFIERS) "total" else "ready-in"
-                LabeledCookDuration(label = label, duration = CookDuration(it.minutes))
+                LabeledCookDuration(label = label, duration = it.duration)
             }
         } else {
             null
         }
 
-        val secondary = if (primary.isNotEmpty()) {
-            mapped.mapNotNull { timing ->
-                timing.passiveLabel?.let { label ->
-                    LabeledCookDuration(label = label, duration = CookDuration(timing.minutes))
-                }
-            }
-        } else {
-            emptyList()
-        }
+        val secondary = all.filter { it.isPassive }
 
         return StructuredIndividualInfo(
             primary = primary,
             fallback = fallback,
-            secondary = secondary
+            secondary = secondary,
+            all = all
         )
+    }
+
+    /**
+     * Converts a [ParsedTiming] into a [LabeledCookDuration], resolving the display label
+     * and tagging passive entries. Returns `null` for fallback-only qualifiers (total / ready-in).
+     */
+    private fun ParsedTiming.toLabeledCookDuration(): LabeledCookDuration? {
+        return when {
+            qualifier in PRIMARY_QUALIFIERS -> LabeledCookDuration(
+                label = if (qualifier in PREP_QUALIFIERS) "prep" else "cook",
+                duration = duration
+            )
+            passiveLabel != null -> LabeledCookDuration(
+                label = passiveLabel,
+                duration = duration,
+                isPassive = true
+            )
+            else -> null
+        }
     }
 }

--- a/library/src/commonTest/kotlin/com/gu/recipe/CookTimeUtilsTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/CookTimeUtilsTest.kt
@@ -59,33 +59,15 @@ class CookTimeUtilsTest {
     }
 
     @Test
-    fun `long duration stays in hr format`() {
+    fun `long duration below day threshold stays in hr format`() {
         val input = listOf(
-            timing("prep-time", 4320), // 3 days
+            timing("prep-time", 4320), // 72 hr (3 days, below 4-day threshold)
             timing("cook-time", 60)
         )
 
         val result = utils.format(input)
 
         assertEquals("73 hr", result)
-    }
-
-    @Test
-    fun `primary time crossing twenty four hours stays in hr format`() {
-        val input = listOf(
-            timing("prep-time", 900),  // 15 hr
-            timing("cook-time", 600)   // 10 hr
-        )
-
-        val result = utils.format(input)
-
-        assertEquals("25 hr", result)
-    }
-
-    @Test
-    fun `single value displays minutes`() {
-        val input = listOf(timing("prep-time", 10))
-        assertEquals("10 min", utils.format(input))
     }
 
     @Test
@@ -103,12 +85,6 @@ class CookTimeUtilsTest {
             timing("prep-time", 30),
             timing("cook-time", 90)
         )
-        assertEquals("2 hr", utils.format(input))
-    }
-
-    @Test
-    fun `hours do not pluralise`() {
-        val input = listOf(timing("cook-time", 120))
         assertEquals("2 hr", utils.format(input))
     }
 
@@ -148,33 +124,11 @@ class CookTimeUtilsTest {
     }
 
     @Test
-    fun `combined minutes above fifty nine convert to hour minute format`() {
-        val input = listOf(
-            timing("prep-time", 30),
-            timing("cook-time", 40)
-        )
-
-        assertEquals("1 hr 10 min", utils.format(input))
-    }
-
-    @Test
     fun `decimal minute values round and do not display decimals`() {
         val input = listOf(
             Timing(
                 qualifier = "total-time",
                 durationInMins = Range(min = 89.6, max = null)
-            )
-        )
-
-        assertEquals("1 hr 30 min", utils.format(input))
-    }
-
-    @Test
-    fun `fractional hour source values convert to hr and min`() {
-        val input = listOf(
-            Timing(
-                qualifier = "total-time",
-                durationInMins = Range(min = 90.0, max = 90.0)
             )
         )
 
@@ -189,16 +143,6 @@ class CookTimeUtilsTest {
         )
 
         assertEquals("25 min", utils.format(input))
-    }
-
-    @Test
-    fun `cook only wins over total fallback`() {
-        val input = listOf(
-            timing("cook-time", 35),
-            timing("total-time", 90)
-        )
-
-        assertEquals("35 min", utils.format(input))
     }
 
     @Test
@@ -273,12 +217,12 @@ class CookTimeUtilsTest {
 
         assertEquals(2, structured.primary.size)
         assertEquals("prep", structured.primary[0].label)
-        assertEquals(10, structured.primary[0].duration.minutes)
+        assertEquals(10, structured.primary[0].duration.minMinutes)
         assertEquals("cook", structured.primary[1].label)
-        assertEquals(20, structured.primary[1].duration.minutes)
+        assertEquals(20, structured.primary[1].duration.minMinutes)
         assertEquals(1, structured.secondary.size)
         assertEquals("chill", structured.secondary[0].label)
-        assertEquals(30, structured.secondary[0].duration.minutes)
+        assertEquals(30, structured.secondary[0].duration.minMinutes)
         assertNull(structured.fallback)
     }
 
@@ -293,7 +237,7 @@ class CookTimeUtilsTest {
 
         assertEquals(0, structured.primary.size)
         assertEquals("total", structured.fallback?.label)
-        assertEquals(90, structured.fallback?.duration?.minutes)
+        assertEquals(90, structured.fallback?.duration?.minMinutes)
         assertEquals(0, structured.secondary.size)
     }
 
@@ -303,10 +247,9 @@ class CookTimeUtilsTest {
 
         assertEquals(0, structured.primary.size)
         assertEquals("ready-in", structured.fallback?.label)
-        assertEquals(45, structured.fallback?.duration?.minutes)
+        assertEquals(45, structured.fallback?.duration?.minMinutes)
         assertEquals(0, structured.secondary.size)
     }
-
 
     @Test
     fun `formatToItems returns prep and cook as separate items`() {
@@ -327,20 +270,20 @@ class CookTimeUtilsTest {
     }
 
     @Test
-    fun `formatToItems includes secondary passive items after primary`() {
+    fun `formatToItems should maintain incoming ordering of times`() {
         val input = listOf(
-            timing("prep-time", 20),
-            timing("cook-time", 10),
-            timing("rest-time", 40)
+            timing("prep-time", 10),
+            timing("marinate-time", 30),
+            timing("cook-time", 50)
         )
 
         val result = utils.formatToItems(input)
 
         assertEquals(
             listOf(
-                mapOf("Prep" to "20 min"),
-                mapOf("Cook" to "10 min"),
-                mapOf("Rest" to "40 min")
+                mapOf("Prep" to "10 min"),
+                mapOf("Marinate" to "30 min"),
+                mapOf("Cook" to "50 min")
             ),
             result
         )
@@ -368,7 +311,7 @@ class CookTimeUtilsTest {
     fun `formatToItems uses unicode fractions for passive day durations`() {
         val input = listOf(
             timing("prep-time", 30),
-            timing("marinate-time", 720)
+            timing("marinate-time", 6480) // 4.5 days = 4 days + 720 min (½ day)
         )
 
         val result = utils.formatToItems(input)
@@ -376,7 +319,7 @@ class CookTimeUtilsTest {
         assertEquals(
             listOf(
                 mapOf("Prep" to "30 min"),
-                mapOf("Marinate" to "½ day")
+                mapOf("Marinate" to "4½ days")
             ),
             result
         )
@@ -409,7 +352,7 @@ class CookTimeUtilsTest {
         assertEquals(
             listOf(
                 mapOf("Prep" to "15 min"),
-                mapOf("Ferment" to "168 hr")
+                mapOf("Ferment" to "7 - 10 days")
             ),
             result
         )
@@ -425,6 +368,156 @@ class CookTimeUtilsTest {
 
         assertEquals(
             listOf(mapOf("Prep" to "3 min")),
+            result
+        )
+    }
+
+    /* ----------------------------- */
+    /* RANGE FORMATTING              */
+    /* ----------------------------- */
+
+    @Test
+    fun `format displays range when min and max differ`() {
+        val input = listOf(
+            Timing(qualifier = "prep-time", durationInMins = Range(min = 20.0, max = 30.0))
+        )
+
+        assertEquals("20 - 30 min", utils.format(input))
+    }
+
+    @Test
+    fun `format displays mixed unit range`() {
+        val input = listOf(
+            Timing(qualifier = "total-time", durationInMins = Range(min = 70.0, max = 90.0))
+        )
+
+        assertEquals("1 hr 10 min - 1 hr 30 min", utils.format(input))
+    }
+
+    @Test
+    fun `format combines prep and cook ranges`() {
+        val input = listOf(
+            Timing(qualifier = "prep-time", durationInMins = Range(min = 10.0, max = 15.0)),
+            Timing(qualifier = "cook-time", durationInMins = Range(min = 20.0, max = 25.0))
+        )
+
+        assertEquals("30 - 40 min", utils.format(input))
+    }
+
+    @Test
+    fun `format range with passive shows label only`() {
+        val input = listOf(
+            Timing(qualifier = "prep-time", durationInMins = Range(min = 20.0, max = 30.0)),
+            timing("rest-time", 10)
+        )
+
+        assertEquals("20 - 30 min + rest", utils.format(input))
+    }
+
+    @Test
+    fun `formatToItems displays range for individual items`() {
+        val input = listOf(
+            Timing(qualifier = "prep-time", durationInMins = Range(min = 20.0, max = 30.0)),
+            Timing(qualifier = "cook-time", durationInMins = Range(min = 40.0, max = 50.0))
+        )
+
+        val result = utils.formatToItems(input)
+
+        assertEquals(
+            listOf(
+                mapOf("Prep" to "20 - 30 min"),
+                mapOf("Cook" to "40 - 50 min")
+            ),
+            result
+        )
+    }
+
+    /* ----------------------------- */
+    /* DAY CONVERSION                */
+    /* ----------------------------- */
+
+    @Test
+    fun `format converts to days unit at threshold`() {
+        val input = listOf(timing("total-time", 5760)) // exactly 4 days
+
+        assertEquals("4 days", utils.format(input))
+    }
+
+    @Test
+    fun `format stays in hr below day threshold`() {
+        val input = listOf(timing("total-time", 5759)) // just below 4 days
+
+        assertEquals("95 hr 59 min", utils.format(input))
+    }
+
+    @Test
+    fun `format displays fractional day with unicode fraction`() {
+        val input = listOf(timing("total-time", 6480)) // 4.5 days
+
+        assertEquals("4½ days", utils.format(input))
+    }
+
+    @Test
+    fun `format displays quarter day fraction`() {
+        val input = listOf(timing("total-time", 6120)) // 4.25 days
+
+        assertEquals("4¼ days", utils.format(input))
+    }
+
+    @Test
+    fun `format falls back to hr for non quarter day remainder`() {
+        val input = listOf(timing("total-time", 6000)) // 4 days + 240 min (not a quarter day)
+
+        assertEquals("100 hr", utils.format(input))
+    }
+
+
+    @Test
+    fun `formatToItems passive whole days`() {
+        val input = listOf(
+            timing("prep-time", 20),
+            timing("soak-time", 8640) // 6 days
+        )
+
+        val result = utils.formatToItems(input)
+
+        assertEquals(
+            listOf(
+                mapOf("Prep" to "20 min"),
+                mapOf("Soak" to "6 days")
+            ),
+            result
+        )
+    }
+
+    @Test
+    fun `formatToItems passive below day threshold uses hr`() {
+        val input = listOf(
+            timing("prep-time", 30),
+            timing("marinate-time", 720) // 12 hr, below 4-day threshold
+        )
+
+        val result = utils.formatToItems(input)
+
+        assertEquals(
+            listOf(
+                mapOf("Prep" to "30 min"),
+                mapOf("Marinate" to "12 hr")
+            ),
+            result
+        )
+    }
+
+    @Test
+    fun `formatToItems orders range as min to max even when source is swapped`() {
+        val input = listOf(
+            Timing(qualifier = "cook-time", durationInMins = Range(min = 30.0, max = 25.0))
+        )
+
+        val result = utils.formatToItems(input)
+
+        assertEquals(
+            listOf(mapOf("Cook" to "25 - 30 min")),
             result
         )
     }

--- a/library/src/commonTest/kotlin/com/gu/recipe/CookTimeUtilsTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/CookTimeUtilsTest.kt
@@ -437,10 +437,17 @@ class CookTimeUtilsTest {
     /* ----------------------------- */
 
     @Test
-    fun `format converts to days unit at threshold`() {
-        val input = listOf(timing("total-time", 5760)) // exactly 4 days
+    fun `format uses hr at exactly four days`() {
+        val input = listOf(timing("total-time", 5760)) // exactly 4 days = 96 hr
 
-        assertEquals("4 days", utils.format(input))
+        assertEquals("96 hr", utils.format(input))
+    }
+
+    @Test
+    fun `format converts to days unit above four days`() {
+        val input = listOf(timing("total-time", 7200)) // 5 days
+
+        assertEquals("5 days", utils.format(input))
     }
 
     @Test


### PR DESCRIPTION
## What does this change?
Due to change in requirements we needed revisit the current implementation and update them. This PR changes includes:
- Support range in formatted time (e.g `20 - 30 min`)
- Show day values only when more than 4 days
- Fixed a ordering bug, now preserves the order of original times (no 'marinate' after 'cooking')

I will add updated timing spec perhaps in doc/wiki for future references.

The logic rules are captured [here](https://github.com/guardian/feast-multiplatform-library/wiki/Cooktime-display-logic)

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Make sure unit tests are passing.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

