### PR TITLE
Fix singular unit for stick

### DIFF
--- a/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
@@ -90,9 +90,10 @@ class TemplateSession(private val densityTable: DensityTable) {
             else -> true
         }
         val unitString = if (amount.unit != null) {
-            if (max(amount.min, amount.max ?: amount.min) > 1.1f) { //need to offset from exactly one, so that when rounding a value below 1/8 we don't get "1 cups
+            val value = max(amount.min, amount.max ?: amount.min)
+            if (value > 1.05f) { // Treat values greater than 1.05 as plural
                 " ${amount.unit.symbolPlural}"
-            } else {
+            } else { // Treat values close to 1 (e.g., 0.95 to 1.05) as singular
                 " ${amount.unit.symbol}"
             }
         } else ""

--- a/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
@@ -91,10 +91,10 @@ class TemplateSession(private val densityTable: DensityTable) {
         }
         val unitString = if (amount.unit != null) {
             val value = max(amount.min, amount.max ?: amount.min)
-            if (value > 1.05f) { // Treat values greater than 1.05 as plural
-                " ${amount.unit.symbolPlural}"
-            } else { // Treat values close to 1 (e.g., 0.95 to 1.05) as singular
+            if (value >= 1.0f && value < 1.5f) { // Treat values between 1.0 and 1.5 as singular
                 " ${amount.unit.symbol}"
+            } else { // Treat other values as plural
+                " ${amount.unit.symbolPlural}"
             }
         } else ""
 

--- a/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
@@ -90,11 +90,10 @@ class TemplateSession(private val densityTable: DensityTable) {
             else -> true
         }
         val unitString = if (amount.unit != null) {
-            val value = max(amount.min, amount.max ?: amount.min)
-            if (value >= 1.0f && value < 1.5f) { // Treat values between 1.0 and 1.5 as singular
-                " ${amount.unit.symbol}"
-            } else { // Treat other values as plural
+            if (max(amount.min, amount.max ?: amount.min) > 1.1f) { //need to offset from exactly one, so that when rounding a value below 1/8 we don't get "1 cups
                 " ${amount.unit.symbolPlural}"
+            } else {
+                " ${amount.unit.symbol}"
             }
         } else ""
 

--- a/library/src/commonMain/kotlin/com/gu/recipe/unit/MeasurementUnit.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/unit/MeasurementUnit.kt
@@ -34,7 +34,7 @@ object Units {
         singular = "stick",
         plural = "sticks",
         symbolPlural = "sticks",
-        symbol = "sticks",
+        symbol = "stick",
         unitType = UnitType.VOLUME,
         measuringSystems = setOf(MeasuringSystem.USCustomary, MeasuringSystem.Imperial),
         quantity = 118.294f,    //in ml

--- a/library/src/commonTest/kotlin/com/gu/recipe/RenderTemplateTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/RenderTemplateTest.kt
@@ -638,7 +638,7 @@ class RenderTemplateTest {
             )
         )
         val result = session.renderTemplate(template, 1f, MeasuringSystem.USCombined)
-        assertEquals("118 g (1 sticks • ½ cup) of butter", result)
+        assertEquals("118 g (1 stick • ½ cup) of butter", result)
     }
 }
 


### PR DESCRIPTION
## What does this change?

This will address the issue of unitisation (singular/plural) when we have an exact value of 1 or up to 1.05 of density.
Just needed text update.

## How to test

- run the tests
- check on CODE

## How can we measure success?

- tests should pass
- unit conversion should be accurate for any value even 1


## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
