### PR TITLE
Attempt to fix ios Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,8 +112,8 @@ jobs:
               repo: context.repo.repo,
               tag_name: version,
               name: `Release ${version}`,
-              draft: false,
-              prerelease: true,
+              draft: true,
+              prerelease: false,
               generate_release_notes: false
             });
             


### PR DESCRIPTION
## What does this change?

This PR fixes an issue where ios-release job fails due to github release already done the time it run ios job, the fix is to not make the github release a final - rather make it draft and then make it final later stage in the workflow