### PR TITLE
Sa/update order of ingredients unit for us units

### DIFF
--- a/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
@@ -31,7 +31,9 @@ private fun splitBeforeSuffix(value: String): Pair<String, String?> {
 }
 
 internal fun wrapWithStrongTag(value: String): String {
-    // Rule: once comma/semicolon appears, everything after it is plain text.
+    // Rule: bold text runs until the first comma/semicolon; anything after that stays plain text,
+    // and any parenthesized groups within the boldable portion also remain plain while surrounding
+    // text may still be bold.
     val suffixStart = value.indexOfAny(charArrayOf(',', ';'))
     val boldPart = if (suffixStart >= 0) value.take(suffixStart) else value
     val plainSuffix = if (suffixStart >= 0) value.drop(suffixStart) else ""

--- a/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
@@ -19,7 +19,7 @@ import kotlin.js.ExperimentalJsExport
 import kotlin.js.JsExport
 import kotlin.math.max
 
-private val BRACKET_GROUP_REGEX = Regex("""\([^()]*\)""")
+private val BRACKET_GROUP_REGEX = Regex("""\([^()]*\)|•""")
 
 private fun splitBeforeSuffix(value: String): Pair<String, String?> {
     val index = value.indexOfAny(charArrayOf(',', ';', '('))

--- a/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
@@ -126,7 +126,7 @@ class TemplateSession(private val densityTable: DensityTable) {
                             } else {
                                 //NOTE - according to https://kotlinlang.org/docs/strings.html#string-formatting String.format()
                                 //only works on JVM; therefore we can't use it here
-                                metricPart + " (" + cupsPart + ")"
+                                cupsPart + " (" + metricPart + ")"
                             }
                         }
                     }
@@ -140,7 +140,7 @@ class TemplateSession(private val densityTable: DensityTable) {
                             if (cupsPart == imperialPart) {
                                 cupsPart
                             } else {
-                                imperialPart + " (" + cupsPart + ")"
+                                cupsPart + " (" + imperialPart + ")"
                             }
                         }
                     }
@@ -164,9 +164,9 @@ class TemplateSession(private val densityTable: DensityTable) {
                             if (cupsPart == metricPart && cupsPart == imperialPart) {
                                 metricPart
                             } else if (cupsPart == imperialPart) {
-                                metricPart + " (" + cupsPart + ")"
+                                cupsPart + " (" + metricPart + ")"
                             } else {
-                                metricPart + " (" + imperialPart + " • " + cupsPart + ")"
+                                imperialPart + " • " + cupsPart + " (" + metricPart + ")"
                             }
                         }
                     }

--- a/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
@@ -19,22 +19,46 @@ import kotlin.js.ExperimentalJsExport
 import kotlin.js.JsExport
 import kotlin.math.max
 
-private fun splitBeforeSuffix(value: String): Pair<String, String?> {
-    val separators = charArrayOf(',', ';', '(')
-    val index = value.indexOfAny(separators)
+private val BRACKET_GROUP_REGEX = Regex("""\([^()]*\)""")
 
+private fun splitBeforeSuffix(value: String): Pair<String, String?> {
+    val index = value.indexOfAny(charArrayOf(',', ';', '('))
     return if (index != -1) {
-        val before = value.take(index)
-        val after = value.drop(index)
-        before to after
+        value.take(index) to value.drop(index)
     } else {
         value.trim() to null
     }
 }
 
 internal fun wrapWithStrongTag(value: String): String {
-    val (before, after) = splitBeforeSuffix(value)
-    return "<strong>$before</strong>${after.orEmpty()}"
+    // Rule: once comma/semicolon appears, everything after it is plain text.
+    val suffixStart = value.indexOfAny(charArrayOf(',', ';'))
+    val boldPart = if (suffixStart >= 0) value.take(suffixStart) else value
+    val plainSuffix = if (suffixStart >= 0) value.drop(suffixStart) else ""
+
+    val matches = BRACKET_GROUP_REGEX.findAll(boldPart).toList()
+    if (matches.isEmpty()) return "<strong>$boldPart</strong>$plainSuffix"
+
+    val stringBuilder = StringBuilder()
+    var cursor = 0
+
+    fun appendWrappedChunk(chunk: String) {
+        if (chunk.isEmpty()) return
+        if (chunk.isBlank()) {
+            stringBuilder.append(chunk)
+        } else {
+            stringBuilder.append("<strong>").append(chunk).append("</strong>")
+        }
+    }
+
+    for (match in matches) {
+        appendWrappedChunk(boldPart.substring(cursor, match.range.first))
+        stringBuilder.append(match.value) // Append the bracketed part without strong tags
+        cursor = match.range.last + 1
+    }
+
+    appendWrappedChunk(boldPart.substring(cursor))
+    return stringBuilder.toString() + plainSuffix
 }
 
 @OptIn(ExperimentalJsExport::class)

--- a/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
@@ -19,7 +19,8 @@ import kotlin.js.ExperimentalJsExport
 import kotlin.js.JsExport
 import kotlin.math.max
 
-private val BRACKET_GROUP_REGEX = Regex("""\([^()]*\)|•""")
+private val NON_BOLD_REGEX = Regex("""\([^()]*\)| • """)
+private const val MARKER = "\u0000"
 
 private fun splitBeforeSuffix(value: String): Pair<String, String?> {
     val index = value.indexOfAny(charArrayOf(',', ';', '('))
@@ -38,29 +39,18 @@ internal fun wrapWithStrongTag(value: String): String {
     val boldPart = if (suffixStart >= 0) value.take(suffixStart) else value
     val plainSuffix = if (suffixStart >= 0) value.drop(suffixStart) else ""
 
-    val matches = BRACKET_GROUP_REGEX.findAll(boldPart).toList()
-    if (matches.isEmpty()) return "<strong>$boldPart</strong>$plainSuffix"
-
-    val stringBuilder = StringBuilder()
-    var cursor = 0
-
-    fun appendWrappedChunk(chunk: String) {
-        if (chunk.isEmpty()) return
-        if (chunk.isBlank()) {
-            stringBuilder.append(chunk)
-        } else {
-            stringBuilder.append("<strong>").append(chunk).append("</strong>")
+    val result = NON_BOLD_REGEX.replace(boldPart) { "$MARKER${it.value}$MARKER" }
+        .split(MARKER)
+        .joinToString("") { chunk ->
+            when {
+                chunk.isEmpty() -> ""
+                chunk.startsWith("(") -> chunk
+                chunk.isBlank() || chunk == " • " -> chunk
+                else -> "<strong>$chunk</strong>"
+            }
         }
-    }
 
-    for (match in matches) {
-        appendWrappedChunk(boldPart.substring(cursor, match.range.first))
-        stringBuilder.append(match.value) // Append the bracketed part without strong tags
-        cursor = match.range.last + 1
-    }
-
-    appendWrappedChunk(boldPart.substring(cursor))
-    return stringBuilder.toString() + plainSuffix
+    return result + plainSuffix
 }
 
 @OptIn(ExperimentalJsExport::class)

--- a/library/src/commonTest/kotlin/com/gu/recipe/RenderTemplateTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/RenderTemplateTest.kt
@@ -482,7 +482,7 @@ class RenderTemplateTest {
             )
         )
         val result = session.renderTemplate(template, 1f, MeasuringSystem.USCustomaryWithMetric)
-        assertEquals("100 ml (½ cup) of water, 120 ml (½ cup) of oil", result)
+        assertEquals("½ cup (100 ml) of water, ½ cup (120 ml) of oil", result)
     }
 
     @Test
@@ -506,7 +506,7 @@ class RenderTemplateTest {
             )
         )
         val result = session.renderTemplate(template, 1f, MeasuringSystem.USCombined)
-        assertEquals("100 ml (½ cup) of water, 120 ml (½ cup) of oil", result)
+        assertEquals("½ cup (100 ml) of water, ½ cup (120 ml) of oil", result)
     }
 
     @Test
@@ -530,7 +530,7 @@ class RenderTemplateTest {
             )
         )
         val result = session.renderTemplate(template, 1f, MeasuringSystem.USCustomaryWithImperial)
-        assertEquals("3⅓ fl oz (½ cup) of water, 4 fl oz (½ cup) of oil", result)
+        assertEquals("½ cup (3⅓ fl oz) of water, ½ cup (4 fl oz) of oil", result)
     }
 
     @Test
@@ -566,7 +566,7 @@ class RenderTemplateTest {
             )
         )
         val result = session.renderTemplate(template, 1f, MeasuringSystem.USCombined)
-        assertEquals("100 g (3½ oz) of vegan pork", result)
+        assertEquals("3½ oz (100 g) of vegan pork", result)
     }
 
     @Test
@@ -619,7 +619,7 @@ class RenderTemplateTest {
             )
         )
         val result = session.renderTemplate(template, 1f, MeasuringSystem.USCustomaryWithMetric)
-        assertEquals("100 g (3½ oz) of vegan pork", result)
+        assertEquals("3½ oz (100 g) of vegan pork", result)
     }
 
     @Test
@@ -638,7 +638,7 @@ class RenderTemplateTest {
             )
         )
         val result = session.renderTemplate(template, 1f, MeasuringSystem.USCombined)
-        assertEquals("118 g (1 stick • ½ cup) of butter", result)
+        assertEquals("1 stick • ½ cup (118 g) of butter", result)
     }
 }
 

--- a/library/src/commonTest/kotlin/com/gu/recipe/ScaleRecipeTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/ScaleRecipeTest.kt
@@ -89,6 +89,8 @@ class ScaleRecipeTest {
 
     @Test
     fun `wrapWithStrongTag should wrap text before first punctuation`() {
+        assertEquals("<strong>100 ml kefir</strong>", wrapWithStrongTag("100 ml kefir"))
+        assertEquals("<strong>1/2 cup </strong>(100 ml)<strong> kefir</strong>", wrapWithStrongTag("1/2 cup (100 ml) kefir"))
         assertEquals("<strong>1-2 of something</strong>", wrapWithStrongTag("1-2 of something"))
         assertEquals("<strong>1-2 kg oranges</strong>, organic", wrapWithStrongTag("1-2 kg oranges, organic"))
         assertEquals("<strong>150 g mayonnaise </strong>(homemade or shop-bought)", wrapWithStrongTag("150 g mayonnaise (homemade or shop-bought)"))

--- a/library/src/commonTest/kotlin/com/gu/recipe/ScaleRecipeTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/ScaleRecipeTest.kt
@@ -89,7 +89,7 @@ class ScaleRecipeTest {
 
     @Test
     fun `wrapWithStrongTag should wrap everything except bracket groups and comma or semicolon suffix`() {
-        assertEquals("<strong>14 oz </strong>•<strong> 3 cups </strong>(400g)<strong> banana shallots </strong>(about 6), peeled, halved lengthways and finely sliced", wrapWithStrongTag("14 oz • 3 cups (400g) banana shallots (about 6), peeled, halved lengthways and finely sliced"))
+        assertEquals("<strong>14 oz</strong> • <strong>3 cups </strong>(400g)<strong> banana shallots </strong>(about 6), peeled, halved lengthways and finely sliced", wrapWithStrongTag("14 oz • 3 cups (400g) banana shallots (about 6), peeled, halved lengthways and finely sliced"))
         assertEquals("<strong>100 ml kefir</strong>", wrapWithStrongTag("100 ml kefir"))
         assertEquals("<strong>1/2 cup </strong>(100 ml)<strong> kefir</strong>", wrapWithStrongTag("1/2 cup (100 ml) kefir"))
         assertEquals("<strong>1-2 of something</strong>", wrapWithStrongTag("1-2 of something"))

--- a/library/src/commonTest/kotlin/com/gu/recipe/ScaleRecipeTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/ScaleRecipeTest.kt
@@ -88,7 +88,7 @@ class ScaleRecipeTest {
     }
 
     @Test
-    fun `wrapWithStrongTag should wrap text before first punctuation`() {
+    fun `wrapWithStrongTag should wrap everything except bracket groups and comma or semicolon suffix`() {
         assertEquals("<strong>100 ml kefir</strong>", wrapWithStrongTag("100 ml kefir"))
         assertEquals("<strong>1/2 cup </strong>(100 ml)<strong> kefir</strong>", wrapWithStrongTag("1/2 cup (100 ml) kefir"))
         assertEquals("<strong>1-2 of something</strong>", wrapWithStrongTag("1-2 of something"))

--- a/library/src/commonTest/kotlin/com/gu/recipe/ScaleRecipeTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/ScaleRecipeTest.kt
@@ -89,6 +89,7 @@ class ScaleRecipeTest {
 
     @Test
     fun `wrapWithStrongTag should wrap everything except bracket groups and comma or semicolon suffix`() {
+        assertEquals("<strong>14 oz </strong>•<strong> 3 cups </strong>(400g)<strong> banana shallots </strong>(about 6), peeled, halved lengthways and finely sliced", wrapWithStrongTag("14 oz • 3 cups (400g) banana shallots (about 6), peeled, halved lengthways and finely sliced"))
         assertEquals("<strong>100 ml kefir</strong>", wrapWithStrongTag("100 ml kefir"))
         assertEquals("<strong>1/2 cup </strong>(100 ml)<strong> kefir</strong>", wrapWithStrongTag("1/2 cup (100 ml) kefir"))
         assertEquals("<strong>1-2 of something</strong>", wrapWithStrongTag("1-2 of something"))


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Updates US-measuring-system ingredient rendering to display US units first (with metric/imperial equivalents in parentheses) and adjusts `<strong>` wrapping to avoid bolding parenthesized conversions while still bolding surrounding ingredient text.

**Changes:**
- Reordered hybrid US output strings (e.g., cups first, metric in parentheses) across relevant measuring systems.
- Updated `wrapWithStrongTag` to keep parenthesized groups unbolded while bolding the surrounding text segments.
- Updated tests to reflect the new formatting rules.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
all unit tests should be running fine and CI is green

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
all unit tests should be running fine and CI is green

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214110372281130