### PR TITLE
Remove "fluid ounce" unit 

### DIFF
--- a/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
@@ -170,7 +170,9 @@ class TemplateSession(private val densityTable: DensityTable) {
                                 renderQuantity(element, factor, MeasuringSystem.USCustomary)
                         } else {
                             val cupsPart = renderQuantity(element, factor, MeasuringSystem.USCustomary)
-                            val imperialPart = if(unit.unitType==UnitType.VOLUME) {    //don't show extra volumes in US
+                            val imperialPart = if (unit == Units.FLUID_OUNCE) { // Skip rendering fluid ounces
+                                null
+                            } else if (unit.unitType == UnitType.VOLUME) { //don't show extra volumes in US
                                 cupsPart
                             } else {
                                 renderQuantity(element, factor, MeasuringSystem.Imperial)


### PR DESCRIPTION
## What does this change?

US team don't want fluid ounce to be present under the US conversion measuring system 
so we can remove this when rendering

--------------

**BEFORE**:

<img width="790" height="767" alt="image" src="https://github.com/user-attachments/assets/182be2f5-ca16-491e-9f6a-d404e2d1862f" />

--------------

**AFTER**:

<img width="790" height="982" alt="image" src="https://github.com/user-attachments/assets/7d159aa0-8a80-4c39-b79c-0b750e1f2a20" />

--------------


## How to test

Observe any ml conversion like 400 ml mik.


## How can we measure success?

`fl.oz` shouldn't be present

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
