### PR TITLE
Fix CVE-2026-33871

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,3 +3,14 @@ plugins {
     alias(libs.plugins.kotlinMultiplatform) apply  false
     alias(libs.plugins.vanniktech.mavenPublish) apply false
 }
+
+
+// Fix CVE: Netty HTTP/2 CONTINUATION Frame Flood DoS - transitive via AGP 8.12.3 (netty 4.1.110.Final)
+allprojects {
+    configurations.all {
+        resolutionStrategy {
+            force("io.netty:netty-codec-http2:4.1.132.Final")
+        }
+    }
+}
+

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 allprojects {
     configurations.all {
         resolutionStrategy {
-            force("io.netty:netty-codec-http2:4.1.132.Final")
+            force("io.netty:netty-codec-http2:${libs.versions.netty.codec.http2.get()}")
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ metalava = "0.5.0"
 kotlinx-serialization-json = "1.11.0"
 kotlinx-coroutines = "1.10.2"
 okio = "3.17.0"
+netty-codec-http2 = "4.1.132.Final"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }


### PR DESCRIPTION
## What does this change?
This PR should fix three security issues reported by the bot
https://github.com/guardian/feast-multiplatform-library/security/dependabot/45

It now use the patch version of `io.netty:netty-codec-http2`

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Merge and run the bot again
