### PR TITLE
Fix float representation in fractions in Metric

### DIFF
--- a/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
@@ -102,8 +102,7 @@ class TemplateSession(private val densityTable: DensityTable) {
 
         val fraction = when (amount.unit) {
             Units.CENTILITRE, Units.MILLILITRE, Units.CENTIMETRE, Units.GRAM, Units.KILOGRAM, Units.MILLIMETRE -> false
-            Units.METRIC_TEASPOON, Units.METRIC_TABLESPOON, Units.US_TABLESPOON, Units.US_TEASPOON -> true
-            else -> true
+            else -> true // generally for Units.METRIC_TEASPOON, Units.METRIC_TABLESPOON, Units.US_TABLESPOON, Units.US_TEASPOON
         }
 
         val unitString = if (amount.unit != null) {

--- a/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
@@ -102,9 +102,10 @@ class TemplateSession(private val densityTable: DensityTable) {
 
         val fraction = when (amount.unit) {
             Units.CENTILITRE, Units.MILLILITRE, Units.CENTIMETRE, Units.GRAM, Units.KILOGRAM, Units.MILLIMETRE -> false
-            Units.METRIC_TEASPOON, Units.METRIC_TABLESPOON, Units.US_TABLESPOON, Units.US_TEASPOON -> amount.min < 1f
+            Units.METRIC_TEASPOON, Units.METRIC_TABLESPOON, Units.US_TABLESPOON, Units.US_TEASPOON -> true
             else -> true
         }
+
         val unitString = if (amount.unit != null) {
             if (max(amount.min, amount.max ?: amount.min) > 1.1f) { //need to offset from exactly one, so that when rounding a value below 1/8 we don't get "1 cups
                 " ${amount.unit.symbolPlural}"

--- a/library/src/commonMain/kotlin/com/gu/recipe/unit/UnitConversions.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/unit/UnitConversions.kt
@@ -41,24 +41,6 @@ object UnitConversions {
         0f to Units.STICK,
     )
 
-    val US_CUSTOMARY_CONVERSION_LADDER = listOf<Pair<Float, MeasurementUnit>>(
-        0f to Units.OUNCE,
-        16f * Units.OUNCE.quantity to Units.POUND,
-
-        // Updated logic: Avoid tbsp conversion until the quantity reaches 4 tbsp, agreed by Editorial to avoid clunky conversions like 1.5 tbsp -> 4.5 tsp.
-        0f to Units.US_TEASPOON,
-        3f * Units.US_TEASPOON.quantity to Units.US_TABLESPOON,
-        4f * Units.US_TEASPOON.quantity to Units.US_TABLESPOON,
-        6f * Units.US_TEASPOON.quantity to Units.US_TABLESPOON,
-        7f * Units.US_TEASPOON.quantity to Units.US_TABLESPOON,
-        9f * Units.US_TEASPOON.quantity to Units.US_TABLESPOON,
-        10f * Units.US_TEASPOON.quantity to Units.US_TABLESPOON,
-        12f * Units.US_TEASPOON.quantity to Units.US_CUP,
-        768f * Units.US_TEASPOON.quantity to Units.US_GALLON,
-
-        0f to Units.INCH,
-    )
-
     val US_TABLESPOON_CONVERSIONS = listOf(3f, 4f, 6f, 7f, 9f, 10f).map {// To Avoid tbsp conversion until the quantity reaches 4 tbsp
         it * Units.US_TEASPOON.quantity to Units.US_TABLESPOON
     }

--- a/library/src/commonMain/kotlin/com/gu/recipe/unit/UnitConversions.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/unit/UnitConversions.kt
@@ -45,18 +45,32 @@ object UnitConversions {
         0f to Units.OUNCE,
         16f * Units.OUNCE.quantity to Units.POUND,
 
-        //This layout reflects requests from editorial to display partial tablespoon as a full number of teaspoon
-        //up to 1/4 cup
+        // Updated logic: Avoid tbsp conversion until the quantity reaches 4 tbsp, agreed by Editorial to avoid clunky conversions like 1.5 tbsp -> 4.5 tsp.
         0f to Units.US_TEASPOON,
         3f * Units.US_TEASPOON.quantity to Units.US_TABLESPOON,
-        4f * Units.US_TEASPOON.quantity to Units.US_TEASPOON,
+        4f * Units.US_TEASPOON.quantity to Units.US_TABLESPOON,
         6f * Units.US_TEASPOON.quantity to Units.US_TABLESPOON,
-        7f * Units.US_TEASPOON.quantity to Units.US_TEASPOON,
+        7f * Units.US_TEASPOON.quantity to Units.US_TABLESPOON,
         9f * Units.US_TEASPOON.quantity to Units.US_TABLESPOON,
-        10f * Units.US_TEASPOON.quantity to Units.US_TEASPOON,
+        10f * Units.US_TEASPOON.quantity to Units.US_TABLESPOON,
         12f * Units.US_TEASPOON.quantity to Units.US_CUP,
         768f * Units.US_TEASPOON.quantity to Units.US_GALLON,
 
+        0f to Units.INCH,
+    )
+
+    val US_TABLESPOON_CONVERSIONS = listOf(3f, 4f, 6f, 7f, 9f, 10f).map {// To Avoid tbsp conversion until the quantity reaches 4 tbsp
+        it * Units.US_TEASPOON.quantity to Units.US_TABLESPOON
+    }
+
+    val US_CUSTOMARY_CONVERSION_LADDER = listOf<Pair<Float, MeasurementUnit>>(
+        0f to Units.OUNCE,
+        16f * Units.OUNCE.quantity to Units.POUND,
+        0f to Units.US_TEASPOON,
+        // Updated logic: We need to avoid tbsp conversion until the quantity reaches 4 tbsp, agreed by Editorial to avoid clunky rounding or conversions like 1.5 tbsp -> 2 tbsp or 4.5 tsp.
+    ) + US_TABLESPOON_CONVERSIONS + listOf(
+        12f * Units.US_TEASPOON.quantity to Units.US_CUP,
+        768f * Units.US_TEASPOON.quantity to Units.US_GALLON,
         0f to Units.INCH,
     )
 

--- a/library/src/commonTest/kotlin/com/gu/recipe/ScaleRecipeTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/ScaleRecipeTest.kt
@@ -5,6 +5,7 @@ import com.gu.recipe.generated.*
 import com.gu.recipe.TemplateSession
 import com.gu.recipe.density.DensityTable
 import com.gu.recipe.ingredientWithoutSuffix
+import com.gu.recipe.template.QuantityPlaceholder
 import com.gu.recipe.wrapWithStrongTag
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -58,7 +59,7 @@ class ScaleRecipeTest {
                         ),
                         IngredientItem(
                             template = """{"min": 0.25, "unit": "tbsp", "scale": true} of salt""",
-                            text = "<strong>2 tsp of salt</strong>"
+                            text = "<strong>1½ tsp of salt</strong>"
                         ),
                         IngredientItem(
                             template = """{"min":1, "scale":true} x {"min":400, "unit":"g", "scale":false} tin chopped tomatoes""",
@@ -108,4 +109,29 @@ class ScaleRecipeTest {
         val ingredient3 = "150 g egg; (small)"
         assertEquals("150 g egg", ingredientWithoutSuffix(ingredient3))
     }
+        @Test
+        fun `test tbsp conversion for 1_5 input`() {
+            // Arrange
+            val densityTable = DensityTable(preparedAt = "none", HashMap(), HashMap())
+            val templateSession = TemplateSession(densityTable)
+            val placeholder = QuantityPlaceholder(
+                min = 1.5f,
+                max = 1.5f,
+                unit = "tbsp",
+                scale = true,
+                ingredient = "lemon juice",
+                usCust = true
+            )
+            val factor = 1.0f
+            val measuringSystem = MeasuringSystem.USCustomary
+
+            // Act
+            val result = templateSession.renderQuantity(placeholder, factor, measuringSystem)
+
+            println("Testcase: result = $result")
+
+            // Assert
+            assertEquals("4½ tsp", result) // I thought of asserting "1½ tbsp", but since 1 US tablespoon is 3 teaspoons, it should convert to 4½ teaspoons instead of showing 1½ tablespoons.
+    }
+
 }

--- a/library/src/commonTest/kotlin/com/gu/recipe/ScaleRecipeTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/ScaleRecipeTest.kt
@@ -128,10 +128,8 @@ class ScaleRecipeTest {
             // Act
             val result = templateSession.renderQuantity(placeholder, factor, measuringSystem)
 
-            println("Testcase: result = $result")
-
             // Assert
-            assertEquals("4½ tsp", result) // I thought of asserting "1½ tbsp", but since 1 US tablespoon is 3 teaspoons, it should convert to 4½ teaspoons instead of showing 1½ tablespoons.
+            assertEquals("1½ tbsp", result)
     }
 
 }

--- a/library/src/commonTest/kotlin/com/gu/recipe/unit/UnitConversionTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/unit/UnitConversionTest.kt
@@ -185,20 +185,19 @@ class UnitConversionTest {
     }
 
     @Test
-    fun `scales US teaspoons to tablespoons and cup at expected thresholds`() {
+    fun `scales US teaspoons to tablespoons and cup at expected thresholds with both whole or float values`() {
         val cases = listOf(
             Triple(0f, 0f, Units.US_TEASPOON),
             Triple(1f, 1f, Units.US_TEASPOON),
             Triple(2f, 2f, Units.US_TEASPOON),
             Triple(3f, 1f, Units.US_TABLESPOON),
-            Triple(4f, 4f, Units.US_TEASPOON),
-            Triple(5f, 5f, Units.US_TEASPOON),
+            Triple(4.5f, 1.5f, Units.US_TABLESPOON),
             Triple(6f, 2f, Units.US_TABLESPOON),
-            Triple(7f, 7f, Units.US_TEASPOON),
-            Triple(8f, 8f, Units.US_TEASPOON),
+            Triple(7.5f, 2.5f, Units.US_TABLESPOON),
+            Triple(8f, 2.6666667f, Units.US_TABLESPOON),//these long values are just for testing the precision of the conversion, they are expected to be shown to users as formatted way
             Triple(9f, 3f, Units.US_TABLESPOON),
-            Triple(10f, 10f, Units.US_TEASPOON),
-            Triple(11f, 11f, Units.US_TEASPOON),
+            Triple(10.5f, 3.5f, Units.US_TABLESPOON),
+            Triple(11f, 3.6666665f, Units.US_TABLESPOON),
             Triple(12f, 0.25f, Units.US_CUP),
         )
 


### PR DESCRIPTION
## What does this change?

Evelyn from Editorial raised concern that `1.5 tbsp` is not showing proper conversion and instead of showing `2.0 tbsp` in Metrics system and converting to tsps in US system

<img width="485" height="235" alt="image" src="https://github.com/user-attachments/assets/7a480ef0-a25f-424e-86fc-04c2c4a17821" />

<img width="485" height="235" alt="image" src="https://github.com/user-attachments/assets/51bcbdde-2710-4a66-8b22-19f5d746d909" />

The conversion library incorrectly rounds decimal tbsp in the Metric system and converts them to teaspoons tsp in the US system.

I discussed this with Laura yesterday (13 May'26) evening, and she kindly agreed to a solution: we should not offer this rounding or conversion until the quantity reaches 4 tbsp.

## How to test

Run the unit tests, we have got one covered for this case too.
By applying this patch in, we should be able to see right conversion in Metrics.

## How can we measure success?

1.5 tbsp should be 1½ tbsp

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
