### PR TITLE
Fix suffix for US combined format

### DIFF
--- a/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
@@ -22,14 +22,9 @@ import kotlin.math.max
 private val NON_BOLD_REGEX = Regex("""\([^()]*\)| • """)
 private const val MARKER = "\u0000"
 
-private fun splitBeforeSuffix(value: String): Pair<String, String?> {
-    val index = value.indexOfAny(charArrayOf(',', ';', '('))
-    return if (index != -1) {
-        value.take(index) to value.drop(index)
-    } else {
-        value.trim() to null
-    }
-}
+// Matches a parenthesized group at the end of the string, e.g. "(homemade or shop-bought)"
+private val TRAILING_PAREN = Regex("""\s*\([^)]*\)\s*$""")
+
 
 internal fun wrapWithStrongTag(value: String): String {
     // Rule: bold text runs until the first comma/semicolon; anything after that stays plain text,
@@ -249,7 +244,21 @@ fun noCustomaryTemplateSession(): TemplateSession {
     return TemplateSession(densityTable)
 }
 
+/**
+ * Extracts the main ingredient name from a rendered ingredient string, stripping any suffix.
+ * A suffix starts at the first comma or semicolon. If neither is found, a trailing
+ * parenthetical group (e.g. "(homemade or shop-bought)") is stripped instead.
+ * Mid-string parentheticals like "(165 g)" or "(large)" that precede a delimiter are preserved.
+ */
 fun ingredientWithoutSuffix(renderedTemplate: String): String {
-    val (before, _) = splitBeforeSuffix(renderedTemplate)
-    return before.trim()
+    // Rule 1: comma/semicolon always wins — take everything before it
+    val delimiterIndex = renderedTemplate.indexOfAny(charArrayOf(',', ';'))
+    if (delimiterIndex != -1) return renderedTemplate.take(delimiterIndex).trim()
+
+    // Rule 2: no delimiter found — strip a trailing parenthetical if present
+    val match = TRAILING_PAREN.find(renderedTemplate)
+    if (match != null) return renderedTemplate.take(match.range.first).trim()
+
+    // No suffix found — the entire string is the ingredient
+    return renderedTemplate.trim()
 }

--- a/library/src/commonTest/kotlin/com/gu/recipe/ScaleRecipeTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/ScaleRecipeTest.kt
@@ -1,11 +1,8 @@
-package io.github.kotlin.fibonacci.com.gu.recipe
+package com.gu.recipe
 
 import com.gu.recipe.unit.MeasuringSystem
 import com.gu.recipe.generated.*
-import com.gu.recipe.TemplateSession
 import com.gu.recipe.density.DensityTable
-import com.gu.recipe.ingredientWithoutSuffix
-import com.gu.recipe.wrapWithStrongTag
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -107,5 +104,39 @@ class ScaleRecipeTest {
 
         val ingredient3 = "150 g egg; (small)"
         assertEquals("150 g egg", ingredientWithoutSuffix(ingredient3))
+
+        val ingredient4 = "5¾ oz • ¾ cup (165 g) short-grain white rice, or pasta if you're inclined"
+        assertEquals("5¾ oz • ¾ cup (165 g) short-grain white rice", ingredientWithoutSuffix(ingredient4))
+
+        val ingredient5 = "2 onions (large), finely chopped"
+        assertEquals("2 onions (large)", ingredientWithoutSuffix(ingredient5))
+
+        // No suffix at all
+        val ingredient6 = "3 cloves garlic"
+        assertEquals("3 cloves garlic", ingredientWithoutSuffix(ingredient6))
+
+        // Metric conversion in parens with no suffix after ingredient
+        val ingredient7 = "1 cup (240 ml) whole milk"
+        assertEquals("1 cup (240 ml) whole milk", ingredientWithoutSuffix(ingredient7))
+
+        // Multiple unit systems with bullet separator and comma suffix
+        val ingredient8 = "7 oz • 1½ cups (200 g) plain flour, plus extra for dusting"
+        assertEquals("7 oz • 1½ cups (200 g) plain flour", ingredientWithoutSuffix(ingredient8))
+
+        // Semicolon suffix with no parens
+        val ingredient9 = "500 g chicken thighs; boneless and skinless"
+        assertEquals("500 g chicken thighs", ingredientWithoutSuffix(ingredient9))
+
+        // Trailing paren qualifier with no comma
+        val ingredient10 = "2 lemons (unwaxed)"
+        assertEquals("2 lemons", ingredientWithoutSuffix(ingredient10))
+
+        // Paren descriptor followed by semicolon
+        val ingredient11 = "3 peppers (mixed colours); deseeded"
+        assertEquals("3 peppers (mixed colours)", ingredientWithoutSuffix(ingredient11))
+
+        // Just a simple ingredient with parens in the middle followed by more text and comma
+        val ingredient12 = "14 oz • 3 cups (400g) banana shallots (about 6), peeled and sliced"
+        assertEquals("14 oz • 3 cups (400g) banana shallots (about 6)", ingredientWithoutSuffix(ingredient12))
     }
 }


### PR DESCRIPTION
## What does this change?
**Problem**
When recipes are rendered in US combined format, the ingredient text now includes parenthesized metric conversions like (165 g) mid-string:
```
"5¾ oz • ¾ cup (165 g) short-grain white rice, or pasta if you're inclined"
```

The old implementation treated ( as a suffix delimiter, so ingredientWithoutSuffix returned only "5¾ oz • ¾ cup" — losing the ingredient name entirely.

**Fix**
Simplified splitBeforeSuffix logic to two rules:
- Split at the first , or ; — parenthesized groups before the delimiter are naturally preserved.
- If no delimiter found, strip only a trailing (...) — catches end-of-string descriptors like (homemade or shop-bought).

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Added unit tests for the broken scenario
