### PR TITLE
Removed metric units when in US conversion mode

### DIFF
--- a/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
@@ -130,35 +130,13 @@ class TemplateSession(private val densityTable: DensityTable) {
             is QuantityPlaceholder -> {
 
                 when (measuringSystem) {
-                    is MeasuringSystem.Metric, is MeasuringSystem.Imperial, is MeasuringSystem.USCustomary, is MeasuringSystem.Butter -> renderQuantity(element, factor, measuringSystem)
-                    is MeasuringSystem.USCustomaryWithMetric -> {
-                        if(element.unit.isNullOrBlank()) {
-                            renderQuantity(element, factor, MeasuringSystem.USCustomary)
-                        } else {
-                            val cupsPart = renderQuantity(element, factor, MeasuringSystem.USCustomary)
-                            val metricPart = renderQuantity(element, factor, MeasuringSystem.Metric)
-                            if (cupsPart == metricPart) {
-                                cupsPart
-                            } else {
-                                //NOTE - according to https://kotlinlang.org/docs/strings.html#string-formatting String.format()
-                                //only works on JVM; therefore we can't use it here
-                                cupsPart + " (" + metricPart + ")"
-                            }
-                        }
-                    }
+                    is MeasuringSystem.Metric,
+                    is MeasuringSystem.Imperial,
+                    is MeasuringSystem.USCustomary,
+                    is MeasuringSystem.Butter -> renderQuantity(element, factor, measuringSystem)
+                    is MeasuringSystem.USCustomaryWithMetric,
                     is MeasuringSystem.USCustomaryWithImperial -> {
-                        if(element.unit.isNullOrBlank()) {
-                            renderQuantity(element, factor, MeasuringSystem.USCustomary)
-                        } else {
-                            val cupsPart = renderQuantity(element, factor, MeasuringSystem.USCustomary)
-                            val imperialPart = renderQuantity(element, factor, MeasuringSystem.Imperial)
-
-                            if (cupsPart == imperialPart) {
-                                cupsPart
-                            } else {
-                                cupsPart + " (" + imperialPart + ")"
-                            }
-                        }
+                        renderQuantity(element, factor, MeasuringSystem.USCustomary)
                     }
                     is MeasuringSystem.USCombined -> {
                         val unit = element.unit?.let { Units.findRecipeUnit(it) }
@@ -169,22 +147,19 @@ class TemplateSession(private val densityTable: DensityTable) {
                             unit==Units.US_TABLESPOON) {
                                 renderQuantity(element, factor, MeasuringSystem.USCustomary)
                         } else {
-                            val cupsPart = renderQuantity(element, factor, MeasuringSystem.USCustomary)
+                            val usCustomaryPart = renderQuantity(element, factor, MeasuringSystem.USCustomary)
                             val imperialPart = if (unit == Units.FLUID_OUNCE) { // Skip rendering fluid ounces
                                 null
-                            } else if (unit.unitType == UnitType.VOLUME) { //don't show extra volumes in US
-                                cupsPart
+                            } else if (unit.unitType == UnitType.VOLUME) {
+                                usCustomaryPart
                             } else {
                                 renderQuantity(element, factor, MeasuringSystem.Imperial)
                             }
-                            val metricPart = renderQuantity(element, factor, MeasuringSystem.Metric)
 
-                            if (cupsPart == metricPart && cupsPart == imperialPart) {
-                                metricPart
-                            } else if (cupsPart == imperialPart) {
-                                cupsPart + " (" + metricPart + ")"
+                            if (usCustomaryPart == imperialPart || imperialPart == null) {
+                                usCustomaryPart
                             } else {
-                                imperialPart + " • " + cupsPart + " (" + metricPart + ")"
+                                imperialPart + " • " + usCustomaryPart
                             }
                         }
                     }

--- a/library/src/commonTest/kotlin/com/gu/recipe/RenderTemplateTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/RenderTemplateTest.kt
@@ -552,7 +552,7 @@ class RenderTemplateTest {
     }
 
     @Test
-    fun `USCombined does not duplicate weight measurements`() {
+    fun `USCombined does not duplicate weight measurements in imperial + cups`() {
         val template = ParsedTemplate(
             listOf(
                 QuantityPlaceholder(

--- a/library/src/commonTest/kotlin/com/gu/recipe/RenderTemplateTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/RenderTemplateTest.kt
@@ -482,7 +482,7 @@ class RenderTemplateTest {
             )
         )
         val result = session.renderTemplate(template, 1f, MeasuringSystem.USCustomaryWithMetric)
-        assertEquals("½ cup (100 ml) of water, ½ cup (120 ml) of oil", result)
+        assertEquals("½ cup of water, ½ cup of oil", result)
     }
 
     @Test
@@ -506,7 +506,7 @@ class RenderTemplateTest {
             )
         )
         val result = session.renderTemplate(template, 1f, MeasuringSystem.USCombined)
-        assertEquals("½ cup (100 ml) of water, ½ cup (120 ml) of oil", result)
+        assertEquals("½ cup of water, ½ cup of oil", result)
     }
 
     @Test
@@ -530,7 +530,7 @@ class RenderTemplateTest {
             )
         )
         val result = session.renderTemplate(template, 1f, MeasuringSystem.USCustomaryWithImperial)
-        assertEquals("½ cup (3⅓ fl oz) of water, ½ cup (4 fl oz) of oil", result)
+        assertEquals("½ cup of water, ½ cup of oil", result)
     }
 
     @Test
@@ -566,7 +566,7 @@ class RenderTemplateTest {
             )
         )
         val result = session.renderTemplate(template, 1f, MeasuringSystem.USCombined)
-        assertEquals("3½ oz (100 g) of vegan pork", result)
+        assertEquals("3½ oz of vegan pork", result)
     }
 
     @Test
@@ -619,7 +619,7 @@ class RenderTemplateTest {
             )
         )
         val result = session.renderTemplate(template, 1f, MeasuringSystem.USCustomaryWithMetric)
-        assertEquals("3½ oz (100 g) of vegan pork", result)
+        assertEquals("3½ oz of vegan pork", result)
     }
 
     @Test
@@ -638,7 +638,7 @@ class RenderTemplateTest {
             )
         )
         val result = session.renderTemplate(template, 1f, MeasuringSystem.USCombined)
-        assertEquals("1 stick • ½ cup (118 g) of butter", result)
+        assertEquals("1 stick • ½ cup of butter", result)
     }
 }
 

--- a/library/src/commonTest/kotlin/com/gu/recipe/RenderTemplateTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/RenderTemplateTest.kt
@@ -534,7 +534,7 @@ class RenderTemplateTest {
     }
 
     @Test
-    fun `USCustomaryWithImperial does not duplicate weight measurements`() {
+    fun `USCustomaryWithImperial does not duplicate weight measurements in imperial + cups`() {
         val template = ParsedTemplate(
             listOf(
                 QuantityPlaceholder(

--- a/library/src/commonTest/kotlin/com/gu/recipe/RenderTemplateTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/RenderTemplateTest.kt
@@ -605,7 +605,7 @@ class RenderTemplateTest {
         assertEquals("½ cup of oil", result)
     }
     @Test
-    fun `USCustomaryWithMetric renders weight as US customary only`() {
+    fun `USCustomaryWithMetric renders weight as US customary only in cups`() {
         val template = ParsedTemplate(
             listOf(
                 QuantityPlaceholder(

--- a/library/src/commonTest/kotlin/com/gu/recipe/RenderTemplateTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/RenderTemplateTest.kt
@@ -486,7 +486,7 @@ class RenderTemplateTest {
     }
 
     @Test
-    fun `USCombined renders only US customary units for volumes`() {
+    fun `USCombined renders only US customary units for volumes means imperial + cups`() {
         val template = ParsedTemplate(
             listOf(
                 QuantityPlaceholder(

--- a/library/src/commonTest/kotlin/com/gu/recipe/RenderTemplateTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/RenderTemplateTest.kt
@@ -570,7 +570,7 @@ class RenderTemplateTest {
     }
 
     @Test
-    fun `USCombined does not duplicate non-standard units`() {
+    fun `USCombined does not duplicate non-standard units in imperial + cups`() {
         val template = ParsedTemplate(
             listOf(
                 QuantityPlaceholder(

--- a/library/src/commonTest/kotlin/com/gu/recipe/RenderTemplateTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/RenderTemplateTest.kt
@@ -462,7 +462,7 @@ class RenderTemplateTest {
     }
 
     @Test
-    fun `render hybrid metric + cups when requested`() {
+    fun `USCustomaryWithMetric renders only US customary units`() {
         val template = ParsedTemplate(
             listOf(
                 QuantityPlaceholder(
@@ -486,7 +486,7 @@ class RenderTemplateTest {
     }
 
     @Test
-    fun `render hybrid metric + imperial + cups when requested`() {
+    fun `USCombined renders only US customary units for volumes`() {
         val template = ParsedTemplate(
             listOf(
                 QuantityPlaceholder(
@@ -510,7 +510,7 @@ class RenderTemplateTest {
     }
 
     @Test
-    fun `render hybrid imperial + cups when requested`() {
+    fun `USCustomaryWithImperial renders only US customary units`() {
         val template = ParsedTemplate(
             listOf(
                 QuantityPlaceholder(
@@ -534,7 +534,7 @@ class RenderTemplateTest {
     }
 
     @Test
-    fun `not duplicate weight measurements in imperial + cups`() {
+    fun `USCustomaryWithImperial does not duplicate weight measurements`() {
         val template = ParsedTemplate(
             listOf(
                 QuantityPlaceholder(
@@ -552,7 +552,7 @@ class RenderTemplateTest {
     }
 
     @Test
-    fun `not duplicate weight measurements in imperial + cups + metric`() {
+    fun `USCombined does not duplicate weight measurements`() {
         val template = ParsedTemplate(
             listOf(
                 QuantityPlaceholder(
@@ -570,7 +570,7 @@ class RenderTemplateTest {
     }
 
     @Test
-    fun `not duplicate non-standard units in imperial + cups + metric`() {
+    fun `USCombined does not duplicate non-standard units`() {
         val template = ParsedTemplate(
             listOf(
                 QuantityPlaceholder(
@@ -588,7 +588,7 @@ class RenderTemplateTest {
     }
 
     @Test
-    fun `render more than 6 tbsp as cups`() {
+    fun `USCombined renders more than 6 tbsp as cups`() {
         val template = ParsedTemplate(
             listOf(
                 QuantityPlaceholder(
@@ -605,7 +605,7 @@ class RenderTemplateTest {
         assertEquals("½ cup of oil", result)
     }
     @Test
-    fun `correctly show weight measurements in metric + cups`() {
+    fun `USCustomaryWithMetric renders weight as US customary only`() {
         val template = ParsedTemplate(
             listOf(
                 QuantityPlaceholder(
@@ -623,7 +623,7 @@ class RenderTemplateTest {
     }
 
     @Test
-    fun `display butter differently to everything else`() {
+    fun `USCombined renders butter as stick and cup without metric bracket`() {
         val template = ParsedTemplate(
             listOf(
                 QuantityPlaceholder(

--- a/library/src/commonTest/kotlin/com/gu/recipe/RenderTemplateTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/RenderTemplateTest.kt
@@ -510,7 +510,7 @@ class RenderTemplateTest {
     }
 
     @Test
-    fun `USCustomaryWithImperial renders only US customary units`() {
+    fun `USCustomaryWithImperial renders only US customary units in imperial + cups`() {
         val template = ParsedTemplate(
             listOf(
                 QuantityPlaceholder(

--- a/library/src/commonTest/kotlin/com/gu/recipe/RenderTemplateTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/RenderTemplateTest.kt
@@ -462,7 +462,7 @@ class RenderTemplateTest {
     }
 
     @Test
-    fun `USCustomaryWithMetric renders only US customary units`() {
+    fun `USCustomaryWithMetric renders only US customary units in cups`() {
         val template = ParsedTemplate(
             listOf(
                 QuantityPlaceholder(


### PR DESCRIPTION
## What does this change?
As part of simplification we do not want to show metric value while in US conversion mode. 

So, instead of this:
```
5¾ oz • ¾ cup (165 g) short-grain white rice
```

We want this:
```
5¾ oz • ¾ cup short-grain white rice
```

This PR just does that + some minor refactoring.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Updated unit tests

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

