### PR TITLE
Add the `appExclusiveBranding` flag to the recipe model

### DIFF
--- a/library/src/commonMain/kotlin/com/gu/recipe/generated/RecipeModels.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/generated/RecipeModels.kt
@@ -16,6 +16,12 @@ import kotlinx.serialization.encoding.*
 @Serializable
 data class RecipeV3 (
     /**
+     * If true, render the recipe with app-exclusive branding and styling. If not present, must
+     * be treated as false.
+     */
+    val appExclusiveBranding: Boolean? = null,
+
+    /**
      * Credit to cookbook or publication source
      */
     val bookCredit: String? = null,
@@ -318,7 +324,7 @@ data class Serves (
     /**
      * Unit for the serving amount (e.g., 'people', 'portions')
      */
-    val unit: String
+    val unit: String? = null
 )
 
 /**


### PR DESCRIPTION
## What does this change?

- Brings the library into line with https://github.com/guardian/recipes-backend/pull/204 by adding the `appExclusiveBranding` flag.  This is a backwards-compatible optional boolean; it should be treated as `false` when not present

## How to test

- Build the app with the updated library in-place
- Check that recipes still render correctly

No other checks atm because client designs are not finished

## How can we measure success?

Keeping the datamodels in sync and able to show the branding as soon as we can

## Have we considered potential risks?

n/a
