### PR TITLE
Fix 1 unit rendered with plural "lbs" 

### DIFF
--- a/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
@@ -106,7 +106,7 @@ class TemplateSession(private val densityTable: DensityTable) {
         }
 
         val unitString = if (amount.unit != null) {
-            if (max(amount.min, amount.max ?: amount.min) > 1.1f) { //need to offset from exactly one, so that when rounding a value below 1/8 we don't get "1 cups
+            if (max(amount.min, amount.max ?: amount.min) >= 1.125f) { //need to offset from exactly one, so that when rounding a value below 1/8 we don't get "1 cups
                 " ${amount.unit.symbolPlural}"
             } else {
                 " ${amount.unit.symbol}"

--- a/library/src/commonTest/kotlin/com/gu/recipe/ScaleRecipeTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/ScaleRecipeTest.kt
@@ -132,4 +132,29 @@ class ScaleRecipeTest {
             assertEquals("1½ tbsp", result)
     }
 
+    @Test
+    fun `test conversion for chicken thigh`() {
+        // Arrange
+        val densityTable = DensityTable(preparedAt = "none", HashMap(), HashMap())
+        val templateSession = TemplateSession(densityTable)
+
+        val placeholder = QuantityPlaceholder(
+            min = 500f,
+            max = 500f,
+            unit = "g",
+            scale = true,
+            ingredient = "chicken or vegetable stock",
+            usCust = true
+        )
+        val factor = 1.0f
+        val measuringSystem2 = MeasuringSystem.USCustomary
+
+        // Act
+        val result = templateSession.renderQuantity(placeholder, factor, measuringSystem2)
+
+        // Assert
+        assertEquals("1 lb", result)
+    }
+
+
 }

--- a/library/src/commonTest/kotlin/com/gu/recipe/ScaleRecipeTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/ScaleRecipeTest.kt
@@ -133,7 +133,7 @@ class ScaleRecipeTest {
     }
 
     @Test
-    fun `test conversion for chicken thigh`() {
+    fun `test conversion for chicken thigh for grams conversion to nearly 1 pound`() {
         // Arrange
         val densityTable = DensityTable(preparedAt = "none", HashMap(), HashMap())
         val templateSession = TemplateSession(densityTable)
@@ -147,13 +147,61 @@ class ScaleRecipeTest {
             usCust = true
         )
         val factor = 1.0f
-        val measuringSystem2 = MeasuringSystem.USCustomary
+        val measuringSystem = MeasuringSystem.USCustomary
 
         // Act
-        val result = templateSession.renderQuantity(placeholder, factor, measuringSystem2)
+        val result = templateSession.renderQuantity(placeholder, factor, measuringSystem)
 
         // Assert
         assertEquals("1 lb", result)
+    }
+
+    @Test
+    fun `test conversion for chicken thigh for grams conversion to 1 with a quarter more`() {
+        // Arrange
+        val densityTable = DensityTable(preparedAt = "none", HashMap(), HashMap())
+        val templateSession = TemplateSession(densityTable)
+
+        val placeholder = QuantityPlaceholder(
+            min = 580f,
+            max = 580f,
+            unit = "g",
+            scale = true,
+            ingredient = "chicken or vegetable stock",
+            usCust = true
+        )
+        val factor = 1.0f
+        val measuringSystem = MeasuringSystem.USCustomary
+
+        // Act
+        val result = templateSession.renderQuantity(placeholder, factor, measuringSystem)
+
+        // Assert
+        assertEquals("1¼ lbs", result)
+    }
+
+    @Test
+    fun `test conversion for chicken thigh for grams conversion to 2`() {
+        // Arrange
+        val densityTable = DensityTable(preparedAt = "none", HashMap(), HashMap())
+        val templateSession = TemplateSession(densityTable)
+
+        val placeholder = QuantityPlaceholder(
+            min = 900f,
+            max = 900f,
+            unit = "g",
+            scale = true,
+            ingredient = "chicken or vegetable stock",
+            usCust = true
+        )
+        val factor = 1.0f
+        val measuringSystem = MeasuringSystem.USCustomary
+
+        // Act
+        val result = templateSession.renderQuantity(placeholder, factor, measuringSystem)
+
+        // Assert
+        assertEquals("2 lbs", result)
     }
 
 


### PR DESCRIPTION
## What does this change?

Editorial reported US conversion error in converting 500g chicken as 1 "lbs"

We found that there is some logic issue in rendering the plural in the range of 0 to 0.125.
Giles suggested to log the bug in the Backlog to check overall logic later and for now to fix this way.

Hence for quick fix, I have aligned formatting untiString with rounding.
But we still need to revisit the logic overall.

I have added the test case to replicate the issue
<img width="503" height="215" alt="image" src="https://github.com/user-attachments/assets/c402c7ce-0c6f-4f9b-b9fb-5a7121c15ff3" />

## How to test

To check locally: Pull the branch and run the tests.
To check in the renderer: Get the library version in the web renderer and check for any recipe with any example like of 500g of chicken converting to US customary

## How can we measure success?

The unit test should pass.
Conversion should makes sense and `1` should not appear with plural string.

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
