### PR TITLE
Track original measurement system

### DIFF
--- a/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
@@ -92,7 +92,7 @@ class TemplateSession(private val densityTable: DensityTable) {
         } else {
             measuringSystem
         }
-        amount = UnitConversions.convertUnitSystemAndScale(amount, targetSystem, factorToUse, density)
+        amount = UnitConversions.convertUnitSystemAndScale(amount, targetSystem, factorToUse, density, originalMeasuringSystem)
 
         val decimals = when (amount.unit) {
             Units.GRAM, Units.MILLILITRE, Units.MILLIMETRE, Units.US_TEASPOON, Units.METRIC_TEASPOON, Units.US_TABLESPOON, Units.METRIC_TABLESPOON -> 0

--- a/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
@@ -189,12 +189,11 @@ class TemplateSession(private val densityTable: DensityTable) {
      */
     fun scaleAndConvertUnitRecipe(recipe: RecipeV3, factor: Float, measuringSystem: MeasuringSystem): RecipeV3 {
         val sourceMeasuringSystem: MeasuringSystem.MeasuringSystemInternal = when(recipe.originalMeasuringSystem) {
-            is "metric" -> MeasuringSystem.Metric
-            is "us" -> MeasuringSystem.USCustomary
-            is "aus-cup" -> MeasuringSystem.Metric
-            is "imperial" -> MeasuringSystem.Imperial
-            is null -> MeasuringSystem.Metric
-            else -> throw IllegalArgumentException("invalid original measuringSystem: " + recipe.originalMeasuringSystem)
+            OriginalMeasuringSystem.Metric -> MeasuringSystem.Metric
+            OriginalMeasuringSystem.Us -> MeasuringSystem.USCustomary
+            OriginalMeasuringSystem.AusCup -> MeasuringSystem.Metric
+            OriginalMeasuringSystem.Imperial -> MeasuringSystem.Imperial
+            null -> MeasuringSystem.Metric
         }
 
         val scaledIngredients = recipe.ingredients?.map { ingredientSection ->

--- a/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/ScaleRecipe.kt
@@ -72,11 +72,11 @@ class TemplateSession(private val densityTable: DensityTable) {
         ).joinToString("")
     }
 
-    internal fun renderQuantity(element: QuantityPlaceholder, factor: Float, measuringSystem: MeasuringSystem.MeasuringSystemInternal): String {
+    internal fun renderQuantity(element: QuantityPlaceholder, factor: Float, measuringSystem: MeasuringSystem.MeasuringSystemInternal, originalMeasuringSystem: MeasuringSystem.MeasuringSystemInternal): String {
         var amount = Amount(
             min = element.min,
             max = if (element.min != element.max) element.max else null,
-            unit = element.unit?.let { Units.findRecipeUnit(it) },
+            unit = element.unit?.let { Units.findRecipeUnit(it, originalMeasuringSystem) },
             //Specific override for butter - this should definitely be in cups but CMS data usually indicates it should be in oz.
             //We will fix the upstream CMS but need to move ahead with testing now.
             usCust = if(element.ingredient=="butter") true else element.usCust,
@@ -123,7 +123,8 @@ class TemplateSession(private val densityTable: DensityTable) {
     internal fun renderTemplateElement(
         element: TemplateElement,
         factor: Float,
-        measuringSystem: MeasuringSystem
+        measuringSystem: MeasuringSystem,
+        originalMeasuringSystem: MeasuringSystem.MeasuringSystemInternal,
     ): String {
         return when (element) {
             is TemplateConst -> element.value
@@ -133,27 +134,27 @@ class TemplateSession(private val densityTable: DensityTable) {
                     is MeasuringSystem.Metric,
                     is MeasuringSystem.Imperial,
                     is MeasuringSystem.USCustomary,
-                    is MeasuringSystem.Butter -> renderQuantity(element, factor, measuringSystem)
+                    is MeasuringSystem.Butter -> renderQuantity(element, factor, measuringSystem, originalMeasuringSystem)
                     is MeasuringSystem.USCustomaryWithMetric,
                     is MeasuringSystem.USCustomaryWithImperial -> {
-                        renderQuantity(element, factor, MeasuringSystem.USCustomary)
+                        renderQuantity(element, factor, MeasuringSystem.USCustomary, originalMeasuringSystem)
                     }
                     is MeasuringSystem.USCombined -> {
-                        val unit = element.unit?.let { Units.findRecipeUnit(it) }
+                        val unit = element.unit?.let { Units.findRecipeUnit(it, originalMeasuringSystem) }
                         if( unit==null ||
                             unit==Units.METRIC_TEASPOON ||
                             unit==Units.METRIC_TABLESPOON ||
                             unit==Units.US_TEASPOON ||
                             unit==Units.US_TABLESPOON) {
-                                renderQuantity(element, factor, MeasuringSystem.USCustomary)
+                                renderQuantity(element, factor, MeasuringSystem.USCustomary, originalMeasuringSystem)
                         } else {
-                            val usCustomaryPart = renderQuantity(element, factor, MeasuringSystem.USCustomary)
+                            val usCustomaryPart = renderQuantity(element, factor, MeasuringSystem.USCustomary, originalMeasuringSystem)
                             val imperialPart = if (unit == Units.FLUID_OUNCE) { // Skip rendering fluid ounces
                                 null
                             } else if (unit.unitType == UnitType.VOLUME) {
                                 usCustomaryPart
                             } else {
-                                renderQuantity(element, factor, MeasuringSystem.Imperial)
+                                renderQuantity(element, factor, MeasuringSystem.Imperial, originalMeasuringSystem)
                             }
 
                             if (usCustomaryPart == imperialPart || imperialPart == null) {
@@ -169,9 +170,9 @@ class TemplateSession(private val densityTable: DensityTable) {
         }
     }
 
-    internal fun renderTemplate(template: ParsedTemplate, factor: Float, measuringSystem: MeasuringSystem): String {
+    internal fun renderTemplate(template: ParsedTemplate, factor: Float, measuringSystem: MeasuringSystem, originalMeasuringSystem: MeasuringSystem.MeasuringSystemInternal): String {
         val renderedParts = template.elements.map { element ->
-            renderTemplateElement(element, factor, measuringSystem)
+            renderTemplateElement(element, factor, measuringSystem, originalMeasuringSystem)
         }
 
         return applySmartPunctuation(renderedParts.joinToString(""))
@@ -187,11 +188,20 @@ class TemplateSession(private val densityTable: DensityTable) {
      * @param measuringSystem The target unit system for ingredient measurements (e.g., Metric or Imperial)
      */
     fun scaleAndConvertUnitRecipe(recipe: RecipeV3, factor: Float, measuringSystem: MeasuringSystem): RecipeV3 {
+        val sourceMeasuringSystem: MeasuringSystem.MeasuringSystemInternal = when(recipe.originalMeasuringSystem) {
+            is "metric" -> MeasuringSystem.Metric
+            is "us" -> MeasuringSystem.USCustomary
+            is "aus-cup" -> MeasuringSystem.Metric
+            is "imperial" -> MeasuringSystem.Imperial
+            is null -> MeasuringSystem.Metric
+            else -> throw IllegalArgumentException("invalid original measuringSystem: " + recipe.originalMeasuringSystem)
+        }
+
         val scaledIngredients = recipe.ingredients?.map { ingredientSection ->
             IngredientsList(
                 ingredientsList = ingredientSection.ingredientsList?.map { templateIngredient ->
                     val scaledText = templateIngredient.template?.let { template ->
-                        wrapWithStrongTag(renderTemplate(parseTemplate(template), factor, measuringSystem))
+                        wrapWithStrongTag(renderTemplate(parseTemplate(template), factor, measuringSystem, sourceMeasuringSystem))
                     } ?: templateIngredient.text
 
                     templateIngredient.copy(text = scaledText)
@@ -201,7 +211,7 @@ class TemplateSession(private val densityTable: DensityTable) {
         }
         val scaledInstructions = recipe.instructions?.map { instruction ->
             val description = instruction.descriptionTemplate?.let { template ->
-                renderTemplate(parseTemplate(template), factor, measuringSystem)
+                renderTemplate(parseTemplate(template), factor, measuringSystem, sourceMeasuringSystem)
             }
             instruction.copy(description = description ?: instruction.description)
         }

--- a/library/src/commonMain/kotlin/com/gu/recipe/generated/RecipeModels.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/generated/RecipeModels.kt
@@ -102,6 +102,12 @@ data class RecipeV3 (
     val mealTypeIds: List<String?>? = null,
 
     /**
+     * The original measuring system used in the recipe. This is a view hint for conversion and
+     * should not be taken as a strict source of truth.
+     */
+    val originalMeasuringSystem: OriginalMeasuringSystem? = null,
+
+    /**
      * Information about how many people the recipe serves
      */
     val serves: List<Serves>? = null,
@@ -305,6 +311,18 @@ data class Instruction (
      */
     val stepNumber: Double? = null
 )
+
+/**
+ * The original measuring system used in the recipe. This is a view hint for conversion and
+ * should not be taken as a strict source of truth.
+ */
+@Serializable
+enum class OriginalMeasuringSystem(val value: String) {
+    @SerialName("aus-cup") AusCup("aus-cup"),
+    @SerialName("imperial") Imperial("imperial"),
+    @SerialName("metric") Metric("metric"),
+    @SerialName("us") Us("us");
+}
 
 /**
  * Information about how many servings the recipe makes

--- a/library/src/commonMain/kotlin/com/gu/recipe/unit/MeasurementUnit.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/unit/MeasurementUnit.kt
@@ -295,10 +295,19 @@ object Units {
      * Find a unit coming from a recipe.
      * Because we know it's coming from a recipe we bias it towards metric units first
      */
-    fun findRecipeUnit(name: String): MeasurementUnit {
-        val unit = METRIC_UNIT_FROM_SYMBOL[name]
-            ?: IMPERIAL_UNIT_FROM_SYMBOL[name]
-            ?: US_CUSTOMARY_UNIT_FROM_SYMBOL[name]
+    fun findRecipeUnit(name: String, measuringSystem: MeasuringSystem.MeasuringSystemInternal): MeasurementUnit {
+        val unit = when(measuringSystem) {
+            is MeasuringSystem.Metric -> METRIC_UNIT_FROM_SYMBOL[name]
+                ?: IMPERIAL_UNIT_FROM_SYMBOL[name]
+                ?: US_CUSTOMARY_UNIT_FROM_SYMBOL[name]
+            //butter is a crazy thing to be measuring the whole recipe in but we need it to complete the enum
+            is MeasuringSystem.USCustomary, MeasuringSystem.Butter -> US_CUSTOMARY_UNIT_FROM_SYMBOL[name]
+                ?: IMPERIAL_UNIT_FROM_SYMBOL[name]
+                ?: METRIC_UNIT_FROM_SYMBOL[name]
+            is MeasuringSystem.Imperial -> IMPERIAL_UNIT_FROM_SYMBOL[name]
+                ?: METRIC_UNIT_FROM_SYMBOL[name]
+                ?: US_CUSTOMARY_UNIT_FROM_SYMBOL[name]
+        }
 
         if (unit != null) {
             return unit

--- a/library/src/commonMain/kotlin/com/gu/recipe/unit/MeasurementUnit.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/unit/MeasurementUnit.kt
@@ -295,8 +295,8 @@ object Units {
      * Find a unit coming from a recipe.
      * Because we know it's coming from a recipe we bias it towards metric units first
      */
-    fun findRecipeUnit(name: String, measuringSystem: MeasuringSystem.MeasuringSystemInternal): MeasurementUnit {
-        val unit = when(measuringSystem) {
+    fun findRecipeUnit(name: String, originMeasuringSystem: MeasuringSystem.MeasuringSystemInternal): MeasurementUnit {
+        val unit = when(originMeasuringSystem) {
             is MeasuringSystem.Metric -> METRIC_UNIT_FROM_SYMBOL[name]
                 ?: IMPERIAL_UNIT_FROM_SYMBOL[name]
                 ?: US_CUSTOMARY_UNIT_FROM_SYMBOL[name]

--- a/library/src/commonMain/kotlin/com/gu/recipe/unit/UnitConversions.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/unit/UnitConversions.kt
@@ -1,6 +1,7 @@
 package com.gu.recipe.unit
 
 import com.gu.recipe.Amount
+import com.gu.recipe.generated.OriginalMeasuringSystem
 
 object UnitConversions {
     private val CUPS_PER_ML = 0.00422675f
@@ -100,15 +101,17 @@ object UnitConversions {
         }
     }
 
-    fun convertUnitSystemAndScale(amount: Amount, target: MeasuringSystem.MeasuringSystemInternal, factor: Float = 1f, density: Float?): Amount {
+    fun convertUnitSystemAndScale(amount: Amount, target: MeasuringSystem.MeasuringSystemInternal, factor: Float = 1f, density: Float?, originalMeasuringSystem: MeasuringSystem.MeasuringSystemInternal): Amount {
         val scaledAmount = amount.copy(min = amount.min * factor, max = amount.max?.let { it * factor })
 
-        if (scaledAmount.unit == null || (target == MeasuringSystem.Metric && factor == 1f)) {
+        if (scaledAmount.unit == null || (target == originalMeasuringSystem && factor == 1f)) {
             return scaledAmount
         }
 
+        println("applying scaling")
         val smallestUnitAmount = toSmallestUnit(scaledAmount)
 
+        println("smallestAmount: $smallestUnitAmount")
         val ladder = when (target) {
             MeasuringSystem.Metric -> if (CONVENIENCE_UNITS.contains(amount.unit))
                 METRIC_CONVENIENCE_LADDER
@@ -123,6 +126,8 @@ object UnitConversions {
             MeasuringSystem.Imperial -> IMPERIAL_CONVERSION_LADDER
             MeasuringSystem.Butter -> BUTTER_CONVERSION_LADDER
         }
+
+        println("ladder: $ladder")
 
         val amountToConvert = if(
             (target== MeasuringSystem.Butter && density !=null) ||
@@ -140,10 +145,13 @@ object UnitConversions {
             smallestUnitAmount
         }
 
+        println("amountToConvert: $amountToConvert")
+
         val mostRelevantUnit = ladder
             .filter { it.second.unitType == amountToConvert.unit?.unitType }
             .lastOrNull { amountToConvert.min >= it.first }?.second
 
+        println("mostRelevantUnit: $mostRelevantUnit")
         return mostRelevantUnit?.let {
             Amount(
                 min = amountToConvert.min / it.quantity,

--- a/library/src/commonMain/kotlin/com/gu/recipe/unit/UnitConversions.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/unit/UnitConversions.kt
@@ -108,10 +108,8 @@ object UnitConversions {
             return scaledAmount
         }
 
-        println("applying scaling")
         val smallestUnitAmount = toSmallestUnit(scaledAmount)
 
-        println("smallestAmount: $smallestUnitAmount")
         val ladder = when (target) {
             MeasuringSystem.Metric -> if (CONVENIENCE_UNITS.contains(amount.unit))
                 METRIC_CONVENIENCE_LADDER
@@ -126,8 +124,6 @@ object UnitConversions {
             MeasuringSystem.Imperial -> IMPERIAL_CONVERSION_LADDER
             MeasuringSystem.Butter -> BUTTER_CONVERSION_LADDER
         }
-
-        println("ladder: $ladder")
 
         val amountToConvert = if(
             (target== MeasuringSystem.Butter && density !=null) ||
@@ -145,13 +141,10 @@ object UnitConversions {
             smallestUnitAmount
         }
 
-        println("amountToConvert: $amountToConvert")
-
         val mostRelevantUnit = ladder
             .filter { it.second.unitType == amountToConvert.unit?.unitType }
             .lastOrNull { amountToConvert.min >= it.first }?.second
 
-        println("mostRelevantUnit: $mostRelevantUnit")
         return mostRelevantUnit?.let {
             Amount(
                 min = amountToConvert.min / it.quantity,

--- a/library/src/commonMain/kotlin/com/gu/recipe/unit/UnitConversions.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/unit/UnitConversions.kt
@@ -1,7 +1,6 @@
 package com.gu.recipe.unit
 
 import com.gu.recipe.Amount
-import com.gu.recipe.generated.OriginalMeasuringSystem
 
 object UnitConversions {
     private val CUPS_PER_ML = 0.00422675f
@@ -101,10 +100,10 @@ object UnitConversions {
         }
     }
 
-    fun convertUnitSystemAndScale(amount: Amount, target: MeasuringSystem.MeasuringSystemInternal, factor: Float = 1f, density: Float?, originalMeasuringSystem: MeasuringSystem.MeasuringSystemInternal): Amount {
+    fun convertUnitSystemAndScale(amount: Amount, target: MeasuringSystem.MeasuringSystemInternal, factor: Float = 1f, density: Float?, origin: MeasuringSystem.MeasuringSystemInternal): Amount {
         val scaledAmount = amount.copy(min = amount.min * factor, max = amount.max?.let { it * factor })
 
-        if (scaledAmount.unit == null || (target == originalMeasuringSystem && factor == 1f)) {
+        if (scaledAmount.unit == null || (target == origin && factor == 1f)) {
             return scaledAmount
         }
 

--- a/library/src/commonTest/kotlin/com/gu/recipe/RenderTemplateTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/RenderTemplateTest.kt
@@ -23,7 +23,7 @@ class RenderTemplateTest {
                 )
             )
         )
-        val result = session.renderTemplate(template, 2f, MeasuringSystem.Metric)
+        val result = session.renderTemplate(template, 2f, MeasuringSystem.Metric, MeasuringSystem.Metric)
         assertEquals("200 g", result)
     }
 
@@ -39,7 +39,7 @@ class RenderTemplateTest {
                 )
             )
         )
-        val result = session.renderTemplate(template, 2f, MeasuringSystem.Metric)
+        val result = session.renderTemplate(template, 2f, MeasuringSystem.Metric, MeasuringSystem.Metric)
         assertEquals("200-300 g", result)
     }
 
@@ -54,7 +54,7 @@ class RenderTemplateTest {
                 )
             )
         )
-        val result = session.renderTemplate(template, 2f, MeasuringSystem.Metric)
+        val result = session.renderTemplate(template, 2f, MeasuringSystem.Metric, MeasuringSystem.Metric)
         assertEquals("1 tbsp", result)
     }
 
@@ -69,7 +69,7 @@ class RenderTemplateTest {
                 )
             )
         )
-        val result = session.renderTemplate(template, 2f, MeasuringSystem.Metric)
+        val result = session.renderTemplate(template, 2f, MeasuringSystem.Metric, MeasuringSystem.Metric)
         assertEquals("½ tsp", result)
     }
 
@@ -84,7 +84,7 @@ class RenderTemplateTest {
                 )
             )
         )
-        val result = session.renderTemplate(template, 0.5f, MeasuringSystem.Metric)
+        val result = session.renderTemplate(template, 0.5f, MeasuringSystem.Metric, MeasuringSystem.Metric)
         assertEquals("¾ cup", result)
     }
 
@@ -98,7 +98,7 @@ class RenderTemplateTest {
                 )
             )
         )
-        val result = session.renderTemplate(template, 0.25f, MeasuringSystem.Metric)
+        val result = session.renderTemplate(template, 0.25f, MeasuringSystem.Metric, MeasuringSystem.Metric)
         assertEquals("½", result)
     }
 
@@ -115,7 +115,7 @@ class RenderTemplateTest {
                 )
             )
         )
-        val result = session.renderTemplate(template, 1.0f, MeasuringSystem.USCustomary)
+        val result = session.renderTemplate(template, 1.0f, MeasuringSystem.USCustomary, MeasuringSystem.Metric)
         assertEquals("1 cup", result)
     }
 
@@ -132,7 +132,7 @@ class RenderTemplateTest {
                 )
             )
         )
-        val result = session.renderTemplate(template, 1.0f, MeasuringSystem.USCustomary)
+        val result = session.renderTemplate(template, 1.0f, MeasuringSystem.USCustomary, MeasuringSystem.Metric)
         assertEquals("8¾ oz", result)
     }
 
@@ -150,7 +150,7 @@ class RenderTemplateTest {
                 )
             )
         )
-        val result = session.renderTemplate(template, 1.0f, MeasuringSystem.USCustomary)
+        val result = session.renderTemplate(template, 1.0f, MeasuringSystem.USCustomary, MeasuringSystem.Metric)
         assertEquals("1⅓-3¼ cups", result)
     }
 
@@ -167,7 +167,7 @@ class RenderTemplateTest {
                 )
             )
         )
-        val result = session.renderTemplate(template, 2.0f, MeasuringSystem.USCustomary)
+        val result = session.renderTemplate(template, 2.0f, MeasuringSystem.USCustomary, MeasuringSystem.Metric)
         assertEquals("2 cups", result) //extra 1/8 due to rounding
     }
 
@@ -182,7 +182,7 @@ class RenderTemplateTest {
                 )
             )
         )
-        val result = session.renderTemplate(template, 1.234567f, MeasuringSystem.Metric)
+        val result = session.renderTemplate(template, 1.234567f, MeasuringSystem.Metric, MeasuringSystem.Metric)
         assertEquals("309 ml", result)
     }
 
@@ -197,7 +197,7 @@ class RenderTemplateTest {
                 )
             )
         )
-        val result = session.renderTemplate(template, 2f, MeasuringSystem.Metric)
+        val result = session.renderTemplate(template, 2f, MeasuringSystem.Metric, MeasuringSystem.Metric)
         assertEquals("100 g", result)
     }
 
@@ -211,7 +211,7 @@ class RenderTemplateTest {
                 )
             )
         )
-        val result = session.renderTemplate(template, 2f, MeasuringSystem.Metric)
+        val result = session.renderTemplate(template, 2f, MeasuringSystem.Metric, MeasuringSystem.Metric)
         assertEquals("180C (160C fan)", result)
     }
 
@@ -224,7 +224,7 @@ class RenderTemplateTest {
                 )
             )
         )
-        val result = session.renderTemplate(template, 2f, MeasuringSystem.Metric)
+        val result = session.renderTemplate(template, 2f, MeasuringSystem.Metric, MeasuringSystem.Metric)
         assertEquals("200C", result)
     }
 
@@ -235,7 +235,7 @@ class RenderTemplateTest {
                 TemplateConst("Add ")
             )
         )
-        val result = session.renderTemplate(template, 2f, MeasuringSystem.Metric)
+        val result = session.renderTemplate(template, 2f, MeasuringSystem.Metric, MeasuringSystem.Metric)
         assertEquals("Add ", result)
     }
 
@@ -253,7 +253,7 @@ class RenderTemplateTest {
                 TemplateConst(" of flour")
             )
         )
-        val result = session.renderTemplate(template, 2f, MeasuringSystem.Metric)
+        val result = session.renderTemplate(template, 2f, MeasuringSystem.Metric, MeasuringSystem.Metric)
         assertEquals("Add 200-240 g of flour", result)
     }
 
@@ -276,7 +276,7 @@ class RenderTemplateTest {
                 TemplateConst(".")
             )
         )
-        val result = session.renderTemplate(template, 2f, MeasuringSystem.Metric)
+        val result = session.renderTemplate(template, 2f, MeasuringSystem.Metric, MeasuringSystem.Metric)
         assertEquals("Bake at 180C (160C fan) for 30-40 minutes.", result)
     }
 
@@ -291,7 +291,7 @@ class RenderTemplateTest {
                 )
             )
         )
-        val result = session.renderTemplate(template, 0.5f, MeasuringSystem.Metric)
+        val result = session.renderTemplate(template, 0.5f, MeasuringSystem.Metric, MeasuringSystem.Metric)
         assertEquals("100 g", result)
     }
 
@@ -306,7 +306,7 @@ class RenderTemplateTest {
                 )
             )
         )
-        val result = session.renderTemplate(template, 1.5f, MeasuringSystem.Metric)
+        val result = session.renderTemplate(template, 1.5f, MeasuringSystem.Metric, MeasuringSystem.Metric)
         assertEquals("1.5 kg", result)
     }
 
@@ -320,7 +320,7 @@ class RenderTemplateTest {
                 )
             )
         )
-        val result = session.renderTemplate(template, 0.75f, MeasuringSystem.Metric)
+        val result = session.renderTemplate(template, 0.75f, MeasuringSystem.Metric, MeasuringSystem.Metric)
         assertEquals("¾", result)
     }
 
@@ -336,7 +336,7 @@ class RenderTemplateTest {
                 )
             )
         )
-        val result = session.renderTemplate(template, 2f, MeasuringSystem.Metric)
+        val result = session.renderTemplate(template, 2f, MeasuringSystem.Metric, MeasuringSystem.Metric)
         assertEquals("1-2 tsp", result)
     }
 
@@ -351,7 +351,7 @@ class RenderTemplateTest {
                 )
             )
         )
-        val result = session.renderTemplate(template, 2f, MeasuringSystem.Metric)
+        val result = session.renderTemplate(template, 2f, MeasuringSystem.Metric, MeasuringSystem.Metric)
         assertEquals("4 kg", result)
     }
 
@@ -374,7 +374,7 @@ class RenderTemplateTest {
                 ),
             )
         )
-        val result = session.renderTemplate(template, 2f, MeasuringSystem.Metric)
+        val result = session.renderTemplate(template, 2f, MeasuringSystem.Metric, MeasuringSystem.Metric)
         assertEquals("4 kg 2 kg", result)
     }
 
@@ -395,7 +395,7 @@ class RenderTemplateTest {
                 ),
             )
         )
-        val result = session.renderTemplate(template, 1f, MeasuringSystem.Metric)
+        val result = session.renderTemplate(template, 1f, MeasuringSystem.Metric, MeasuringSystem.Metric)
         assertEquals("1½ cups 1½ lbs", result)
     }
 
@@ -422,7 +422,7 @@ class RenderTemplateTest {
                 ),
             )
         )
-        val result = session.renderTemplate(template, 1f, MeasuringSystem.Imperial)
+        val result = session.renderTemplate(template, 1f, MeasuringSystem.Imperial, MeasuringSystem.Metric)
         assertEquals("3⅓ lbs 3½ oz 1", result)
     }
 
@@ -446,7 +446,7 @@ class RenderTemplateTest {
                 TemplateConst(" of oil"),
             )
         )
-        val result = session.renderTemplate(template, 1f, MeasuringSystem.USCustomary)
+        val result = session.renderTemplate(template, 1f, MeasuringSystem.USCustomary, MeasuringSystem.Metric)
         assertEquals("½ cup of water, ½ cup of oil", result)
     }
 
@@ -457,7 +457,7 @@ class RenderTemplateTest {
                 TemplateConst("Use \"00\" flour and you'll get - I think - the best results."),
             )
         )
-        val result = session.renderTemplate(template, 1f, MeasuringSystem.Metric)
+        val result = session.renderTemplate(template, 1f, MeasuringSystem.Metric, MeasuringSystem.Metric)
         assertEquals("Use “00” flour and you’ll get – I think – the best results.", result)
     }
 
@@ -481,7 +481,7 @@ class RenderTemplateTest {
                 TemplateConst(" of oil"),
             )
         )
-        val result = session.renderTemplate(template, 1f, MeasuringSystem.USCustomaryWithMetric)
+        val result = session.renderTemplate(template, 1f, MeasuringSystem.USCustomaryWithMetric, MeasuringSystem.Metric)
         assertEquals("½ cup of water, ½ cup of oil", result)
     }
 
@@ -505,7 +505,7 @@ class RenderTemplateTest {
                 TemplateConst(" of oil"),
             )
         )
-        val result = session.renderTemplate(template, 1f, MeasuringSystem.USCombined)
+        val result = session.renderTemplate(template, 1f, MeasuringSystem.USCombined, MeasuringSystem.Metric)
         assertEquals("½ cup of water, ½ cup of oil", result)
     }
 
@@ -529,7 +529,7 @@ class RenderTemplateTest {
                 TemplateConst(" of oil"),
             )
         )
-        val result = session.renderTemplate(template, 1f, MeasuringSystem.USCustomaryWithImperial)
+        val result = session.renderTemplate(template, 1f, MeasuringSystem.USCustomaryWithImperial, MeasuringSystem.Metric)
         assertEquals("½ cup of water, ½ cup of oil", result)
     }
 
@@ -547,7 +547,7 @@ class RenderTemplateTest {
                 TemplateConst(" of vegan pork"),
             )
         )
-        val result = session.renderTemplate(template, 1f, MeasuringSystem.USCustomaryWithImperial)
+        val result = session.renderTemplate(template, 1f, MeasuringSystem.USCustomaryWithImperial, MeasuringSystem.Metric)
         assertEquals("3½ oz of vegan pork", result)
     }
 
@@ -565,7 +565,7 @@ class RenderTemplateTest {
                 TemplateConst(" of vegan pork"),
             )
         )
-        val result = session.renderTemplate(template, 1f, MeasuringSystem.USCombined)
+        val result = session.renderTemplate(template, 1f, MeasuringSystem.USCombined, MeasuringSystem.Metric)
         assertEquals("3½ oz of vegan pork", result)
     }
 
@@ -583,7 +583,7 @@ class RenderTemplateTest {
                 TemplateConst(" of gunpowder"),
             )
         )
-        val result = session.renderTemplate(template, 1f, MeasuringSystem.USCombined)
+        val result = session.renderTemplate(template, 1f, MeasuringSystem.USCombined, MeasuringSystem.Metric)
         assertEquals("5 pinches of gunpowder", result)
     }
 
@@ -601,7 +601,7 @@ class RenderTemplateTest {
                 TemplateConst(" of oil"),
             )
         )
-        val result = session.renderTemplate(template, 1f, MeasuringSystem.USCombined)
+        val result = session.renderTemplate(template, 1f, MeasuringSystem.USCombined, MeasuringSystem.Metric)
         assertEquals("½ cup of oil", result)
     }
     @Test
@@ -618,7 +618,7 @@ class RenderTemplateTest {
                 TemplateConst(" of vegan pork"),
             )
         )
-        val result = session.renderTemplate(template, 1f, MeasuringSystem.USCustomaryWithMetric)
+        val result = session.renderTemplate(template, 1f, MeasuringSystem.USCustomaryWithMetric, MeasuringSystem.Metric)
         assertEquals("3½ oz of vegan pork", result)
     }
 
@@ -637,7 +637,7 @@ class RenderTemplateTest {
                 TemplateConst(" of butter"),
             )
         )
-        val result = session.renderTemplate(template, 1f, MeasuringSystem.USCombined)
+        val result = session.renderTemplate(template, 1f, MeasuringSystem.USCombined, MeasuringSystem.Metric)
         assertEquals("1 stick • ½ cup of butter", result)
     }
 }

--- a/library/src/commonTest/kotlin/com/gu/recipe/ScaleRecipeTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/ScaleRecipeTest.kt
@@ -431,7 +431,7 @@ class ScaleRecipeTest {
     }
 
     @Test
-    fun `should convert imperial cups into imperial cups (not change)`() {
+    fun `should convert imperial cups into imperial cups - passthrough`() {
         val densityTable = DensityTable(preparedAt = "none", HashMap(), HashMap())
         val templateSession = TemplateSession(densityTable)
 

--- a/library/src/commonTest/kotlin/com/gu/recipe/ScaleRecipeTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/ScaleRecipeTest.kt
@@ -204,5 +204,75 @@ class ScaleRecipeTest {
         assertEquals("2 lbs", result)
     }
 
+    @Test
+    fun `should convert metric cups into imperial cups`() {
+        val densityTable = DensityTable(preparedAt = "none", HashMap(), HashMap())
+        val templateSession = TemplateSession(densityTable)
 
+        val placeholder = QuantityPlaceholder(
+            min = 3f,
+            max = 4f,
+            unit = "cups",
+            scale = true,
+            ingredient = "milk",
+            usCust = true
+        )
+
+        val result = templateSession.renderQuantity(
+            placeholder,
+            1.0f,
+            MeasuringSystem.USCustomary,
+            MeasuringSystem.Metric
+        )
+
+        assertEquals("3¼-4¼ cups", result)
+    }
+
+    @Test
+    fun `should convert imperial cups into imperial cups (not change)`() {
+        val densityTable = DensityTable(preparedAt = "none", HashMap(), HashMap())
+        val templateSession = TemplateSession(densityTable)
+
+        val placeholder = QuantityPlaceholder(
+            min = 3f,
+            max = 4f,
+            unit = "cups",
+            scale = true,
+            ingredient = "milk",
+            usCust = true
+        )
+
+        val result = templateSession.renderQuantity(
+            placeholder,
+            1.0f,
+            MeasuringSystem.USCustomary,
+            MeasuringSystem.USCustomary
+        )
+
+        assertEquals("3-4 cups", result)
+    }
+
+    @Test
+    fun `should convert imperial cups into metric cups`() {
+        val densityTable = DensityTable(preparedAt = "none", HashMap(), HashMap())
+        val templateSession = TemplateSession(densityTable)
+
+        val placeholder = QuantityPlaceholder(
+            min = 3f,
+            max = 4f,
+            unit = "cups",
+            scale = true,
+            ingredient = "milk",
+            usCust = true
+        )
+
+        val result = templateSession.renderQuantity(
+            placeholder,
+            1.0f,
+            MeasuringSystem.Metric,
+            MeasuringSystem.USCustomary
+        )
+
+        assertEquals("710-946 ml", result)
+    }
 }

--- a/library/src/commonTest/kotlin/com/gu/recipe/ScaleRecipeTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/ScaleRecipeTest.kt
@@ -126,7 +126,7 @@ class ScaleRecipeTest {
             val measuringSystem = MeasuringSystem.USCustomary
 
             // Act
-            val result = templateSession.renderQuantity(placeholder, factor, measuringSystem)
+            val result = templateSession.renderQuantity(placeholder, factor, measuringSystem, MeasuringSystem.Metric)
 
             // Assert
             assertEquals("1½ tbsp", result)
@@ -150,7 +150,7 @@ class ScaleRecipeTest {
         val measuringSystem = MeasuringSystem.USCustomary
 
         // Act
-        val result = templateSession.renderQuantity(placeholder, factor, measuringSystem)
+        val result = templateSession.renderQuantity(placeholder, factor, measuringSystem, MeasuringSystem.Metric)
 
         // Assert
         assertEquals("1 lb", result)
@@ -174,7 +174,7 @@ class ScaleRecipeTest {
         val measuringSystem = MeasuringSystem.USCustomary
 
         // Act
-        val result = templateSession.renderQuantity(placeholder, factor, measuringSystem)
+        val result = templateSession.renderQuantity(placeholder, factor, measuringSystem, MeasuringSystem.Metric)
 
         // Assert
         assertEquals("1¼ lbs", result)
@@ -198,7 +198,7 @@ class ScaleRecipeTest {
         val measuringSystem = MeasuringSystem.USCustomary
 
         // Act
-        val result = templateSession.renderQuantity(placeholder, factor, measuringSystem)
+        val result = templateSession.renderQuantity(placeholder, factor, measuringSystem, MeasuringSystem.Metric)
 
         // Assert
         assertEquals("2 lbs", result)

--- a/library/src/commonTest/kotlin/com/gu/recipe/ScaleRecipeTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/ScaleRecipeTest.kt
@@ -7,6 +7,7 @@ import com.gu.recipe.density.DensityTable
 import com.gu.recipe.ingredientWithoutSuffix
 import com.gu.recipe.template.QuantityPlaceholder
 import com.gu.recipe.wrapWithStrongTag
+import kotlinx.serialization.json.Json
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -86,6 +87,207 @@ class ScaleRecipeTest {
             expectedRecipe,
             scaledRecipe
         )
+    }
+
+    val htmlTagRegex = "<[^>]+>".toRegex()
+
+    fun stripHTMLFromString(str: String?): String? {
+        if(str == null) {
+            return null
+        } else {
+            return str.replace(htmlTagRegex, "")
+        }
+    }
+    fun stripExtraHTML(recipe: RecipeV3): RecipeV3 {
+        return recipe.copy(
+            ingredients = recipe.ingredients?.map { it.copy(
+                ingredientsList = it.ingredientsList?.map { it.copy(text = stripHTMLFromString(it.text)) }
+            ) }
+        )
+    }
+
+    val usCustomaryRecipeFixture = """{
+"appExclusiveBranding": true,
+"originalMeasuringSystem": "us",
+"bookCredit": "",
+"canonicalArticle": "food/2026/jun/22/ali-slagle",
+"celebrationIds": [],
+"commerceCtas": [],
+"composerId": "6a0f12fe8f089865cf41a3ab",
+"byline": ["Ali Slagle"],
+"cuisineIds": [
+"thai",
+"american"
+],
+"description": "This rendition of fried chicken larb, inspired by one from Thai Diner in New York City, trades ground meat for, excitingly, frozen chicken nuggets; the result is all at once crispy and crunchy, rich and refreshing. Ali Slagle lives in New York and has been developing low-effort, high-reward recipes for home cooks for over a decade",
+"difficultyLevel": "easy",
+"featuredImage": {
+"url": "https://media.guim.co.uk/58504a676bc886d8e98d08b8a07590afb9f4d932/0_0_4388_5483/1601.jpg",
+"mediaId": "58504a676bc886d8e98d08b8a07590afb9f4d932",
+"cropId": "0_0_4388_5483",
+"source": "The Guardian",
+"photographer": "Phoebe Pearson",
+"caption": "Ali Slagle's fried chicken larb.",
+"imageType": "Photograph"
+},
+"id": "9328597b93864c6db9c25d073f19822e",
+"ingredients": [
+{
+"recipeSection": "",
+"ingredientsList": [
+{
+"amount": {
+"min": 1.5,
+"max": 1.5
+},
+"name": "frozen chicken fingers or chicken tenders",
+"template": "{\"min\": 1.5, \"unit\": \"lbs\", \"scale\": true, \"ingredient\": \"frozen chicken finger\", \"usCust\": false} frozen chicken fingers or chicken tenders",
+"text": "1½ lbs frozen chicken fingers or chicken tenders"
+},
+{
+"amount": {
+"min": 3,
+"max": 3
+},
+"name": "lime juice",
+"suffix": "(from 2 limes), plus more as needed",
+"template": "{\"min\": 3, \"unit\": \"tbsp\", \"scale\": true, \"ingredient\": \"lime juice\", \"usCust\": true} lime juice (from {\"min\": 2, \"scale\": true, \"ingredient\": \"lime\"} limes), plus more as needed",
+"text": "3 tbsp lime juice (from 2 limes), plus more as needed",
+"unit": "tbsp"
+},
+{
+"amount": {
+"min": 1,
+"max": 1
+},
+"name": "fish sauce",
+"suffix": ", plus more as needed",
+"template": "{\"min\": 1, \"unit\": \"tbsp\", \"scale\": true, \"ingredient\": \"fish sauce\", \"usCust\": true} fish sauce, plus more as needed",
+"text": "1 tbsp fish sauce, plus more as needed",
+"unit": "tbsp"
+},
+{
+"amount": {
+"min": 2,
+"max": 2
+},
+"name": "red pepper flakes",
+"suffix": "(chilli flakes), plus more as needed",
+"template": "{\"min\": 2, \"unit\": \"tsp\", \"scale\": true, \"ingredient\": \"red pepper flake\", \"usCust\": true} red pepper flakes (chilli flakes), plus more as needed",
+"text": "2 tsp red pepper flakes (chilli flakes), plus more as needed",
+"unit": "tsp"
+},
+{
+"name": "shallot",
+"suffix": ", peeled and thinly sliced",
+"template": "{\"min\": 1, \"scale\": true, \"ingredient\": \"shallot\"} shallot, peeled and thinly sliced",
+"text": "1 shallot, peeled and thinly sliced"
+},
+{
+"amount": {
+"min": 1.5,
+"max": 1.5
+},
+"name": "herb leaves",
+"suffix": "(cilantro, mint, dill and/or basil), torn if large",
+"template": "{\"min\": 1.5, \"unit\": \"cups\", \"scale\": true, \"ingredient\": \"herb leaf\", \"usCust\": true} herb leaves (cilantro, mint, dill and/or basil), torn if large",
+"text": "1½ cups herb leaves (cilantro, mint, dill and/or basil), torn if large",
+"unit": "cups"
+},
+{
+"name": "Cooked rice",
+"suffix": ", lettuce leaves or cucumber, to serve",
+"template": "Cooked rice, lettuce leaves or cucumber, to serve",
+"text": "Cooked rice, lettuce leaves or cucumber, to serve"
+}
+]
+}
+],
+"instructions": [
+{
+"descriptionTemplate": "Heat the oven to {\"temperatureC\": 220, \"temperatureFanC\": 200, \"temperatureF\": 425, \"gasMark\": 7} and place a sheet pan in the oven to heat.",
+"description": "Heat the oven to 220C (200C fan)/425F/gas mark 7 and place a sheet pan in the oven to heat."
+},
+{
+"descriptionTemplate": "Add the chicken fingers and roast, flipping halfway through, for 20 to 25 minutes, until very crisp.",
+"description": "Add the chicken fingers and roast, flipping halfway through, for 20 to 25 minutes, until very crisp."
+},
+{
+"descriptionTemplate": "Let the chicken cool slightly, then roughly chop into bite-size pieces. Transfer to a large bowl.",
+"description": "Let the chicken cool slightly, then roughly chop into bite-size pieces. Transfer to a large bowl."
+},
+{
+"descriptionTemplate": "Add the lime juice, fish sauce, crushed red pepper and shallot and stir to coat.",
+"description": "Add the lime juice, fish sauce, crushed red pepper and shallot and stir to coat."
+},
+{
+"descriptionTemplate": "Add the herbs and toss to combine.",
+"description": "Add the herbs and toss to combine."
+},
+{
+"descriptionTemplate": "Taste and add more fish sauce, lime juice or red pepper flakes until savory, tart and a little spicy.",
+"description": "Taste and add more fish sauce, lime juice or red pepper flakes until savory, tart and a little spicy."
+},
+{
+"descriptionTemplate": "Eat immediately with any combination of rice, lettuce leaves and cucumbers.",
+"description": "Eat immediately with any combination of rice, lettuce leaves and cucumbers."
+}
+],
+"isAppReady": false,
+"mealTypeIds": [
+"dinner",
+"quick",
+"easy",
+"midweek"
+],
+"serves": [
+{
+"amount": {
+"min": 4,
+"max": 4
+},
+"text": "Serves 4",
+"unit": "people"
+}
+],
+"suitableForDietIds": [],
+"techniquesUsedIds": [],
+"timings": [
+{
+"durationInMins": {
+"min": 5,
+"max": 5
+},
+"qualifier": "prep-time",
+"text": "Prep 5 min"
+},
+{
+"durationInMins": {
+"min": 30,
+"max": 30
+},
+"qualifier": "cook-time",
+"text": "Cook 30 min"
+}
+],
+"title": "Fried chicken larb",
+"utensilsAndApplianceIds": []
+}"""
+
+    @Test
+    fun `should render a US customary recipe`() {
+        val densityTable = DensityTable("test", HashMap(), HashMap())
+        val session = TemplateSession(densityTable)
+
+        val recipe: RecipeV3 = Json.decodeFromString(usCustomaryRecipeFixture)
+
+        val scaledRecipe = session.scaleAndConvertUnitRecipe(recipe, 1.0f, MeasuringSystem.USCustomary)
+        //The data we got back has some extra HTML tags for formatting. Remove these so we can compare the values (which is what matters)
+        assertEquals(recipe, stripExtraHTML(scaledRecipe))
+
+        val metricRecipe = session.scaleAndConvertUnitRecipe(recipe, 1.0f, MeasuringSystem.Metric)
+        val jsonStr = Json.encodeToString(metricRecipe)
+        println(jsonStr)
     }
 
     @Test

--- a/library/src/commonTest/kotlin/com/gu/recipe/ScaleRecipeTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/ScaleRecipeTest.kt
@@ -287,7 +287,6 @@ class ScaleRecipeTest {
 
         val metricRecipe = session.scaleAndConvertUnitRecipe(recipe, 1.0f, MeasuringSystem.Metric)
         val jsonStr = Json.encodeToString(metricRecipe)
-        println(jsonStr)
     }
 
     @Test

--- a/library/src/commonTest/kotlin/com/gu/recipe/unit/UnitConversionTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/unit/UnitConversionTest.kt
@@ -10,21 +10,21 @@ class UnitConversionTest {
     @Test
     fun `returns amount unchanged when unit is null`() {
         val amount = Amount(min = 5f, max = 10f, unit = null)
-        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.Imperial, density=1.0f)
+        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.Imperial, density=1.0f, originalMeasuringSystem = MeasuringSystem.Metric)
         assertEquals(amount, result)
     }
 
     @Test
     fun `returns amount unchanged when measuring system is already Metric`() {
         val amount = Amount(min = 1f, max = null, unit = Units.KILOGRAM)
-        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.Metric, density=1.0f)
+        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.Metric, density=1.0f, originalMeasuringSystem = MeasuringSystem.Metric)
         assertEquals(amount, result)
     }
 
     @Test
     fun `converts grams to ounces when target is Imperial`() {
         val amount = Amount(min = 100f, max = 200f, unit = Units.GRAM)
-        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.Imperial, density=1.0f)
+        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.Imperial, density=1.0f, originalMeasuringSystem = MeasuringSystem.Metric)
 
         val expectedMin = 3.527f
         val expectedMax = 7.055f
@@ -36,7 +36,7 @@ class UnitConversionTest {
     @Test
     fun `converts kilograms to pounds when target is Imperial`() {
         val amount = Amount(min = 2f, max = 3f, unit = Units.KILOGRAM)
-        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.Imperial, density=1.0f)
+        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.Imperial, density=1.0f, originalMeasuringSystem = MeasuringSystem.Metric)
 
         val expectedMin = 4.410f
         val expectedMax = 6.614f
@@ -48,7 +48,7 @@ class UnitConversionTest {
     @Test
     fun `converts ml to cups when target is USCustomary`() {
         val amount = Amount(min = 100f, unit = Units.MILLILITRE, usCust = true)
-        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.USCustomary, density=1.0f)
+        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.USCustomary, density=1.0f, originalMeasuringSystem = MeasuringSystem.Metric)
 
         assertEquals(0.423f, result.min, absoluteTolerance = 0.001f)
         assertEquals(Units.US_CUP, result.unit)
@@ -57,7 +57,7 @@ class UnitConversionTest {
     @Test
     fun `converts centimetres to inches when target is Imperial`() {
         val amount = Amount(min = 10f, max = 20f, unit = Units.CENTIMETRE)
-        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.Imperial, density=1.0f)
+        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.Imperial, density=1.0f, originalMeasuringSystem = MeasuringSystem.Metric)
 
         val expectedMin = 3.94f
         val expectedMax = 7.87f
@@ -69,7 +69,7 @@ class UnitConversionTest {
     @Test
     fun `converts millimetres to inches when target is Imperial`() {
         val amount = Amount(min = 10f, max = 20f, unit = Units.MILLIMETRE)
-        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.Imperial, density=1.0f)
+        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.Imperial, density=1.0f, originalMeasuringSystem = MeasuringSystem.Metric)
 
         val expectedMin = 0.39f
         val expectedMax = 0.79f
@@ -81,7 +81,7 @@ class UnitConversionTest {
     @Test
     fun `converts millilitres to cups when target is USCustomary`() {
         val amount = Amount(min = 236.56f, max = 473.12f, unit = Units.MILLILITRE, usCust = true)
-        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.USCustomary, density=1.0f)
+        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.USCustomary, density=1.0f, originalMeasuringSystem = MeasuringSystem.Metric)
 
         assertEquals(1f, result.min, absoluteTolerance = 0.001f)
         assertEquals(2f, result.max!!, absoluteTolerance = 0.001f)
@@ -91,7 +91,7 @@ class UnitConversionTest {
     @Test
     fun `converts litres to cups when target is USCustomary if below quart threshold`() {
         val amount = Amount(min = 0.8f, max = 1.6f, unit = Units.LITRE, usCust = true)
-        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.USCustomary, density=1.0f)
+        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.USCustomary, density=1.0f, originalMeasuringSystem = MeasuringSystem.Metric)
 
         val expectedMin = 3.381f
         val expectedMax = 6.762f
@@ -106,7 +106,7 @@ class UnitConversionTest {
         //an _average_ density of plain flour - seems to be compatible with online recipes. Not the value we carry,
         //but suitable for testing functionality. See https://sallysbakingaddiction.com/master-muffin-recipe/,
         //https://www.google.com/search?q=density+of+plain+flour&sca_esv=d802faf0aaa25922&source=hp&ei=aWV7adfCDai5hbIPg6WgyQg&iflsig=AFdpzrgAAAAAaXtzedfrVDFvuGlKbEwLsZPDl2mlL2B2&ved=0ahUKEwiXm6OB8rCSAxWoXEEAHYMSKIkQ4dUDCBY&uact=5&oq=density+of+plain+flour&gs_lp=Egdnd3Mtd2l6IhZkZW5zaXR5IG9mIHBsYWluIGZsb3VyMgUQABiABDIGEAAYFhgeMgYQABgWGB4yBhAAGBYYHjIGEAAYFhgeMgYQABgWGB4yCxAAGIAEGIoFGIYDMgUQABjvBTIFEAAY7wVI5ExQ8BRYoktwAngAkAEAmAFBoAG6CKoBAjIzuAEDyAEA-AEBmAIZoAL7CKgCCsICChAAGAMYjwEY6gLCAgoQLhgDGI8BGOoCwgIOEAAYgAQYigUYsQMYgwHCAhEQLhiABBixAxiDARjHARjRA8ICCBAAGIAEGLEDwgIOEC4YgAQYsQMYxwEY0QPCAgUQLhiABMICCxAAGIAEGLEDGIMBwgILEC4YgAQYxwEY0QPCAhQQLhiABBiKBRixAxiDARjHARjRA8ICCxAAGIAEGIoFGJIDwgILEC4YgAQYsQMYgwHCAgsQABiABBixAxjJA8ICBBAAGAPCAg4QLhiABBjHARivARiOBcICCBAuGIAEGLEDwgIOEC4YgAQYsQMYxwEYrwHCAggQABiABBiiBJgDA_EFALCFAwj93KmSBwIyNaAH3pcBsgcCMjO4B_IIwgcGMC4yMi4zyAcogAgB&sclient=gws-wiz
-        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.USCustomary, density=0.528f)
+        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.USCustomary, density=0.528f, originalMeasuringSystem = MeasuringSystem.Metric)
 
         val expectedMin = 1.753f
         val expectedMax = 4f
@@ -118,14 +118,14 @@ class UnitConversionTest {
     @Test
     fun `returns amount unchanged when unit is already Imperial`() {
         val amount = Amount(min = 5f, max = 10f, unit = Units.OUNCE)
-        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.Imperial, density=1.0f)
+        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.Imperial, density=1.0f, originalMeasuringSystem = MeasuringSystem.Metric)
         assertEquals(amount, result)
     }
 
     @Test
     fun `handles null max value correctly in conversions`() {
         val amount = Amount(min = 100f, max = null, unit = Units.GRAM)
-        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.Imperial, density=1.0f)
+        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.Imperial, density=1.0f, originalMeasuringSystem = MeasuringSystem.Metric)
 
         val expectedMin = 3.527f
         assertEquals(expectedMin, result.min, absoluteTolerance = 0.001f)
@@ -136,7 +136,7 @@ class UnitConversionTest {
     @Test
     fun `pick the most appropriate unit depending on the quantity ml to gallon`() {
         val amount = Amount(min = 5000f, unit = Units.MILLILITRE)
-        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.Imperial, density=1.0f)
+        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.Imperial, density=1.0f, originalMeasuringSystem = MeasuringSystem.Metric)
 
         val expectedMin = 1.32f
         assertEquals(expectedMin, result.min, absoluteTolerance = 0.001f)
@@ -146,7 +146,7 @@ class UnitConversionTest {
     @Test
     fun `pick the most appropriate unit depending on the quantity cl to cup`() {
         val amount = Amount(min = 10f, unit = Units.CENTILITRE, usCust = true)
-        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.USCustomary, density=1.0f)
+        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.USCustomary, density=1.0f, originalMeasuringSystem = MeasuringSystem.Metric)
 
         val expectedMin = 0.423f
         assertEquals(expectedMin, result.min, absoluteTolerance = 0.001f)
@@ -156,7 +156,7 @@ class UnitConversionTest {
     @Test
     fun `should automatically convert unpractical amounts to most practical one`() {
         val amount = Amount(min = 100f, unit = Units.METRIC_TEASPOON, usCust = true)
-        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.USCustomary, density=1.0f)
+        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.USCustomary, density=1.0f, originalMeasuringSystem = MeasuringSystem.Metric)
 
         val expectedMin = 2.1133f
         assertEquals(expectedMin, result.min, absoluteTolerance = 0.001f)
@@ -166,7 +166,7 @@ class UnitConversionTest {
     @Test
     fun `should NOT touch the quantity or unit if we stay in the metric system without scaling`() {
         val amount = Amount(min = 100f, unit = Units.METRIC_TEASPOON, usCust = true)
-        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.Metric, density=1.0f)
+        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.Metric, density=1.0f, originalMeasuringSystem = MeasuringSystem.Metric)
 
         val expectedMin = 100f
         assertEquals(expectedMin, result.min, absoluteTolerance = 0.001f)
@@ -176,7 +176,7 @@ class UnitConversionTest {
     @Test
     fun `should adapt the unit if the recipe is scaled even if we stay within the same unit system`() {
         val amount = Amount(min = 100f, unit = Units.METRIC_TEASPOON, usCust = true)
-        val result = UnitConversions.convertUnitSystemAndScale(amount, target = MeasuringSystem.Metric, factor = 2f, density = 1.0f)
+        val result = UnitConversions.convertUnitSystemAndScale(amount, target = MeasuringSystem.Metric, factor = 2f, density = 1.0f, originalMeasuringSystem = MeasuringSystem.Metric)
         // 100 metric teaspoons * 2 = 500 ml * 2 = 1 litre
 
         val expectedMin = 1f
@@ -208,6 +208,7 @@ class UnitConversionTest {
                 target = MeasuringSystem.USCustomary,
                 factor = scaledTeaspoons,
                 density = 1.0f,
+                originalMeasuringSystem = MeasuringSystem.Metric
             )
 
             assertEquals(expectedQuantity, result.min, absoluteTolerance = 0.001f)
@@ -219,7 +220,7 @@ class UnitConversionTest {
     @Test
     fun `converts cups to sticks of butter`() {
         val amount = Amount(min=0.5f, unit = Units.US_CUP, usCust = false)
-        val result = UnitConversions.convertUnitSystemAndScale(amount, target = MeasuringSystem.Butter, density=1.0f)
+        val result = UnitConversions.convertUnitSystemAndScale(amount, target = MeasuringSystem.Butter, density=1.0f, originalMeasuringSystem = MeasuringSystem.Metric)
         assertEquals(Units.STICK, result.unit)
         assertEquals(1.00f, result.min, absoluteTolerance = 0.001f)
     }
@@ -227,12 +228,12 @@ class UnitConversionTest {
     @Test
     fun `converts grams to sticks of butter`() {
         val amount = Amount(min=113.0f, unit = Units.GRAM, usCust = false)
-        val result = UnitConversions.convertUnitSystemAndScale(amount, target = MeasuringSystem.Butter, density=0.96f)
+        val result = UnitConversions.convertUnitSystemAndScale(amount, target = MeasuringSystem.Butter, density=0.96f, originalMeasuringSystem = MeasuringSystem.Metric)
         assertEquals(Units.STICK, result.unit)
         assertEquals(1.00f, result.min, absoluteTolerance = 0.01f)
 
         val newAmount = Amount(min=57.0f, unit = Units.GRAM, usCust = true)
-        val newResult = UnitConversions.convertUnitSystemAndScale(newAmount, target = MeasuringSystem.Butter, density=0.96f)
+        val newResult = UnitConversions.convertUnitSystemAndScale(newAmount, target = MeasuringSystem.Butter, density=0.96f, originalMeasuringSystem = MeasuringSystem.Metric)
         assertEquals(Units.STICK, newResult.unit)
         assertEquals(0.5f, newResult.min, absoluteTolerance = 0.01f)
     }

--- a/library/src/commonTest/kotlin/com/gu/recipe/unit/UnitConversionTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/unit/UnitConversionTest.kt
@@ -10,21 +10,21 @@ class UnitConversionTest {
     @Test
     fun `returns amount unchanged when unit is null`() {
         val amount = Amount(min = 5f, max = 10f, unit = null)
-        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.Imperial, density=1.0f, originalMeasuringSystem = MeasuringSystem.Metric)
+        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.Imperial, density=1.0f, origin = MeasuringSystem.Metric)
         assertEquals(amount, result)
     }
 
     @Test
     fun `returns amount unchanged when measuring system is already Metric`() {
         val amount = Amount(min = 1f, max = null, unit = Units.KILOGRAM)
-        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.Metric, density=1.0f, originalMeasuringSystem = MeasuringSystem.Metric)
+        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.Metric, density=1.0f, origin = MeasuringSystem.Metric)
         assertEquals(amount, result)
     }
 
     @Test
     fun `converts grams to ounces when target is Imperial`() {
         val amount = Amount(min = 100f, max = 200f, unit = Units.GRAM)
-        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.Imperial, density=1.0f, originalMeasuringSystem = MeasuringSystem.Metric)
+        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.Imperial, density=1.0f, origin = MeasuringSystem.Metric)
 
         val expectedMin = 3.527f
         val expectedMax = 7.055f
@@ -36,7 +36,7 @@ class UnitConversionTest {
     @Test
     fun `converts kilograms to pounds when target is Imperial`() {
         val amount = Amount(min = 2f, max = 3f, unit = Units.KILOGRAM)
-        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.Imperial, density=1.0f, originalMeasuringSystem = MeasuringSystem.Metric)
+        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.Imperial, density=1.0f, origin = MeasuringSystem.Metric)
 
         val expectedMin = 4.410f
         val expectedMax = 6.614f
@@ -48,7 +48,7 @@ class UnitConversionTest {
     @Test
     fun `converts ml to cups when target is USCustomary`() {
         val amount = Amount(min = 100f, unit = Units.MILLILITRE, usCust = true)
-        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.USCustomary, density=1.0f, originalMeasuringSystem = MeasuringSystem.Metric)
+        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.USCustomary, density=1.0f, origin = MeasuringSystem.Metric)
 
         assertEquals(0.423f, result.min, absoluteTolerance = 0.001f)
         assertEquals(Units.US_CUP, result.unit)
@@ -57,7 +57,7 @@ class UnitConversionTest {
     @Test
     fun `converts centimetres to inches when target is Imperial`() {
         val amount = Amount(min = 10f, max = 20f, unit = Units.CENTIMETRE)
-        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.Imperial, density=1.0f, originalMeasuringSystem = MeasuringSystem.Metric)
+        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.Imperial, density=1.0f, origin = MeasuringSystem.Metric)
 
         val expectedMin = 3.94f
         val expectedMax = 7.87f
@@ -69,7 +69,7 @@ class UnitConversionTest {
     @Test
     fun `converts millimetres to inches when target is Imperial`() {
         val amount = Amount(min = 10f, max = 20f, unit = Units.MILLIMETRE)
-        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.Imperial, density=1.0f, originalMeasuringSystem = MeasuringSystem.Metric)
+        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.Imperial, density=1.0f, origin = MeasuringSystem.Metric)
 
         val expectedMin = 0.39f
         val expectedMax = 0.79f
@@ -81,7 +81,7 @@ class UnitConversionTest {
     @Test
     fun `converts millilitres to cups when target is USCustomary`() {
         val amount = Amount(min = 236.56f, max = 473.12f, unit = Units.MILLILITRE, usCust = true)
-        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.USCustomary, density=1.0f, originalMeasuringSystem = MeasuringSystem.Metric)
+        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.USCustomary, density=1.0f, origin = MeasuringSystem.Metric)
 
         assertEquals(1f, result.min, absoluteTolerance = 0.001f)
         assertEquals(2f, result.max!!, absoluteTolerance = 0.001f)
@@ -91,7 +91,7 @@ class UnitConversionTest {
     @Test
     fun `converts litres to cups when target is USCustomary if below quart threshold`() {
         val amount = Amount(min = 0.8f, max = 1.6f, unit = Units.LITRE, usCust = true)
-        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.USCustomary, density=1.0f, originalMeasuringSystem = MeasuringSystem.Metric)
+        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.USCustomary, density=1.0f, origin = MeasuringSystem.Metric)
 
         val expectedMin = 3.381f
         val expectedMax = 6.762f
@@ -106,7 +106,7 @@ class UnitConversionTest {
         //an _average_ density of plain flour - seems to be compatible with online recipes. Not the value we carry,
         //but suitable for testing functionality. See https://sallysbakingaddiction.com/master-muffin-recipe/,
         //https://www.google.com/search?q=density+of+plain+flour&sca_esv=d802faf0aaa25922&source=hp&ei=aWV7adfCDai5hbIPg6WgyQg&iflsig=AFdpzrgAAAAAaXtzedfrVDFvuGlKbEwLsZPDl2mlL2B2&ved=0ahUKEwiXm6OB8rCSAxWoXEEAHYMSKIkQ4dUDCBY&uact=5&oq=density+of+plain+flour&gs_lp=Egdnd3Mtd2l6IhZkZW5zaXR5IG9mIHBsYWluIGZsb3VyMgUQABiABDIGEAAYFhgeMgYQABgWGB4yBhAAGBYYHjIGEAAYFhgeMgYQABgWGB4yCxAAGIAEGIoFGIYDMgUQABjvBTIFEAAY7wVI5ExQ8BRYoktwAngAkAEAmAFBoAG6CKoBAjIzuAEDyAEA-AEBmAIZoAL7CKgCCsICChAAGAMYjwEY6gLCAgoQLhgDGI8BGOoCwgIOEAAYgAQYigUYsQMYgwHCAhEQLhiABBixAxiDARjHARjRA8ICCBAAGIAEGLEDwgIOEC4YgAQYsQMYxwEY0QPCAgUQLhiABMICCxAAGIAEGLEDGIMBwgILEC4YgAQYxwEY0QPCAhQQLhiABBiKBRixAxiDARjHARjRA8ICCxAAGIAEGIoFGJIDwgILEC4YgAQYsQMYgwHCAgsQABiABBixAxjJA8ICBBAAGAPCAg4QLhiABBjHARivARiOBcICCBAuGIAEGLEDwgIOEC4YgAQYsQMYxwEYrwHCAggQABiABBiiBJgDA_EFALCFAwj93KmSBwIyNaAH3pcBsgcCMjO4B_IIwgcGMC4yMi4zyAcogAgB&sclient=gws-wiz
-        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.USCustomary, density=0.528f, originalMeasuringSystem = MeasuringSystem.Metric)
+        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.USCustomary, density=0.528f, origin = MeasuringSystem.Metric)
 
         val expectedMin = 1.753f
         val expectedMax = 4f
@@ -118,14 +118,14 @@ class UnitConversionTest {
     @Test
     fun `returns amount unchanged when unit is already Imperial`() {
         val amount = Amount(min = 5f, max = 10f, unit = Units.OUNCE)
-        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.Imperial, density=1.0f, originalMeasuringSystem = MeasuringSystem.Metric)
+        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.Imperial, density=1.0f, origin = MeasuringSystem.Metric)
         assertEquals(amount, result)
     }
 
     @Test
     fun `handles null max value correctly in conversions`() {
         val amount = Amount(min = 100f, max = null, unit = Units.GRAM)
-        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.Imperial, density=1.0f, originalMeasuringSystem = MeasuringSystem.Metric)
+        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.Imperial, density=1.0f, origin = MeasuringSystem.Metric)
 
         val expectedMin = 3.527f
         assertEquals(expectedMin, result.min, absoluteTolerance = 0.001f)
@@ -136,7 +136,7 @@ class UnitConversionTest {
     @Test
     fun `pick the most appropriate unit depending on the quantity ml to gallon`() {
         val amount = Amount(min = 5000f, unit = Units.MILLILITRE)
-        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.Imperial, density=1.0f, originalMeasuringSystem = MeasuringSystem.Metric)
+        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.Imperial, density=1.0f, origin = MeasuringSystem.Metric)
 
         val expectedMin = 1.32f
         assertEquals(expectedMin, result.min, absoluteTolerance = 0.001f)
@@ -146,7 +146,7 @@ class UnitConversionTest {
     @Test
     fun `pick the most appropriate unit depending on the quantity cl to cup`() {
         val amount = Amount(min = 10f, unit = Units.CENTILITRE, usCust = true)
-        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.USCustomary, density=1.0f, originalMeasuringSystem = MeasuringSystem.Metric)
+        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.USCustomary, density=1.0f, origin = MeasuringSystem.Metric)
 
         val expectedMin = 0.423f
         assertEquals(expectedMin, result.min, absoluteTolerance = 0.001f)
@@ -156,7 +156,7 @@ class UnitConversionTest {
     @Test
     fun `should automatically convert unpractical amounts to most practical one`() {
         val amount = Amount(min = 100f, unit = Units.METRIC_TEASPOON, usCust = true)
-        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.USCustomary, density=1.0f, originalMeasuringSystem = MeasuringSystem.Metric)
+        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.USCustomary, density=1.0f, origin = MeasuringSystem.Metric)
 
         val expectedMin = 2.1133f
         assertEquals(expectedMin, result.min, absoluteTolerance = 0.001f)
@@ -166,7 +166,7 @@ class UnitConversionTest {
     @Test
     fun `should NOT touch the quantity or unit if we stay in the metric system without scaling`() {
         val amount = Amount(min = 100f, unit = Units.METRIC_TEASPOON, usCust = true)
-        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.Metric, density=1.0f, originalMeasuringSystem = MeasuringSystem.Metric)
+        val result = UnitConversions.convertUnitSystemAndScale(amount, MeasuringSystem.Metric, density=1.0f, origin = MeasuringSystem.Metric)
 
         val expectedMin = 100f
         assertEquals(expectedMin, result.min, absoluteTolerance = 0.001f)
@@ -176,7 +176,7 @@ class UnitConversionTest {
     @Test
     fun `should adapt the unit if the recipe is scaled even if we stay within the same unit system`() {
         val amount = Amount(min = 100f, unit = Units.METRIC_TEASPOON, usCust = true)
-        val result = UnitConversions.convertUnitSystemAndScale(amount, target = MeasuringSystem.Metric, factor = 2f, density = 1.0f, originalMeasuringSystem = MeasuringSystem.Metric)
+        val result = UnitConversions.convertUnitSystemAndScale(amount, target = MeasuringSystem.Metric, factor = 2f, density = 1.0f, origin = MeasuringSystem.Metric)
         // 100 metric teaspoons * 2 = 500 ml * 2 = 1 litre
 
         val expectedMin = 1f
@@ -208,7 +208,7 @@ class UnitConversionTest {
                 target = MeasuringSystem.USCustomary,
                 factor = scaledTeaspoons,
                 density = 1.0f,
-                originalMeasuringSystem = MeasuringSystem.Metric
+                origin = MeasuringSystem.Metric
             )
 
             assertEquals(expectedQuantity, result.min, absoluteTolerance = 0.001f)
@@ -220,7 +220,7 @@ class UnitConversionTest {
     @Test
     fun `converts cups to sticks of butter`() {
         val amount = Amount(min=0.5f, unit = Units.US_CUP, usCust = false)
-        val result = UnitConversions.convertUnitSystemAndScale(amount, target = MeasuringSystem.Butter, density=1.0f, originalMeasuringSystem = MeasuringSystem.Metric)
+        val result = UnitConversions.convertUnitSystemAndScale(amount, target = MeasuringSystem.Butter, density=1.0f, origin = MeasuringSystem.Metric)
         assertEquals(Units.STICK, result.unit)
         assertEquals(1.00f, result.min, absoluteTolerance = 0.001f)
     }
@@ -228,12 +228,12 @@ class UnitConversionTest {
     @Test
     fun `converts grams to sticks of butter`() {
         val amount = Amount(min=113.0f, unit = Units.GRAM, usCust = false)
-        val result = UnitConversions.convertUnitSystemAndScale(amount, target = MeasuringSystem.Butter, density=0.96f, originalMeasuringSystem = MeasuringSystem.Metric)
+        val result = UnitConversions.convertUnitSystemAndScale(amount, target = MeasuringSystem.Butter, density=0.96f, origin = MeasuringSystem.Metric)
         assertEquals(Units.STICK, result.unit)
         assertEquals(1.00f, result.min, absoluteTolerance = 0.01f)
 
         val newAmount = Amount(min=57.0f, unit = Units.GRAM, usCust = true)
-        val newResult = UnitConversions.convertUnitSystemAndScale(newAmount, target = MeasuringSystem.Butter, density=0.96f, originalMeasuringSystem = MeasuringSystem.Metric)
+        val newResult = UnitConversions.convertUnitSystemAndScale(newAmount, target = MeasuringSystem.Butter, density=0.96f, origin = MeasuringSystem.Metric)
         assertEquals(Units.STICK, newResult.unit)
         assertEquals(0.5f, newResult.min, absoluteTolerance = 0.01f)
     }

--- a/library/src/jsMain/kotlin/com/gu/recipe/js/ScaleRecipeJsContract.kt
+++ b/library/src/jsMain/kotlin/com/gu/recipe/js/ScaleRecipeJsContract.kt
@@ -1,6 +1,7 @@
 package com.gu.recipe.js
 
 import com.gu.recipe.TemplateSession
+import com.gu.recipe.generated.OriginalMeasuringSystem
 import com.gu.recipe.unit.MeasuringSystem
 import com.gu.recipe.generated.RecipeV3
 import com.gu.recipe.newTemplateSession
@@ -42,7 +43,7 @@ fun parseTemplate(templateString: String): List<TemplateElement> {
 
 @OptIn(ExperimentalJsExport::class)
 @JsExport
-fun renderTemplate(templateElements: List<TemplateElement>, session: TemplateSession, unit: String): String {
+fun renderTemplate(templateElements: List<TemplateElement>, session: TemplateSession, unit: String, originalUnits: String? = null): String {
     val measuringSystem = when (unit) {
         "Imperial" -> MeasuringSystem.Imperial
         "Metric" -> MeasuringSystem.Metric
@@ -52,8 +53,16 @@ fun renderTemplate(templateElements: List<TemplateElement>, session: TemplateSes
         "Combined" -> MeasuringSystem.USCombined
         else -> throw IllegalArgumentException("Unknown unit: $unit")
     }
+    val originalMeasuringSystem = when (originalUnits) {
+        "imperial" -> MeasuringSystem.Imperial
+        "aus-cups" -> MeasuringSystem.Metric
+        "metric" -> MeasuringSystem.Metric
+        "us" -> MeasuringSystem.USCustomary
+        else -> throw IllegalArgumentException("Unknown unit: $originalUnits")
+    }
+
     val template = ParsedTemplate(templateElements)
-    return session.renderTemplate(template, 1.0f, measuringSystem)
+    return session.renderTemplate(template, 1.0f, measuringSystem, originalMeasuringSystem)
 }
 
 @OptIn(ExperimentalJsExport::class)

--- a/library/src/jsMain/kotlin/com/gu/recipe/js/ScaleRecipeJsContract.kt
+++ b/library/src/jsMain/kotlin/com/gu/recipe/js/ScaleRecipeJsContract.kt
@@ -43,7 +43,7 @@ fun parseTemplate(templateString: String): List<TemplateElement> {
 
 @OptIn(ExperimentalJsExport::class)
 @JsExport
-fun renderTemplate(templateElements: List<TemplateElement>, session: TemplateSession, unit: String, originalUnits: String? = null): String {
+fun renderTemplate(templateElements: List<TemplateElement>, session: TemplateSession, unit: String, originalUnits: String): String {
     val measuringSystem = when (unit) {
         "Imperial" -> MeasuringSystem.Imperial
         "Metric" -> MeasuringSystem.Metric


### PR DESCRIPTION
## What does this change?

- Adds the "original measuring system" field from Composer
- Removes the assumption that a recipe is always published in metric.  Rather, respect the "original measuring system" value
- Update the "passthrough" logic (i.e., bypass any rounding, laddering etc.) from "if metric and 1x" to "if transforming to original measuring system and 1x"

## How to test

- Inline tests prove the functionality both for individual ingredients and for the whole recipe
- Build and deploy into either app or the web renderer.  
- Metric -> metric and metric -> us standard should work as before
- If you select a us authored recipe and select  "us standard" there should be no change
- If you select a us authored recipe and select "metric" it should convert to metric

## How can we measure success?

Remove the "cups confusion"

## Have we considered potential risks?

> [!WARNING]
> Metric conversions are technically accurate but are not ready for release yet.  They don't yet accomodate for tsp, tbsp, volume -> weight etc.
> It's assumed that this PR will be released alongside "hiding" of the conversion switch for US authored recipes until we are ready to handle the extra conversions