### PR TITLE
bump Netty versions for CVE

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,11 +5,15 @@ plugins {
 }
 
 
-// Fix CVE: Netty HTTP/2 CONTINUATION Frame Flood DoS - transitive via AGP 8.12.3 (netty 4.1.110.Final)
+// Fix CVEs: CVE-2026-42583, CVE-2026-42584, CVE-2026-42587, CVE-2026-45416, CVE-2026-44249, CVE-2026-50010
+// Force all affected Netty artifacts to patched version (transitive via AGP)
 allprojects {
     configurations.all {
         resolutionStrategy {
-            force("io.netty:netty-codec-http2:${libs.versions.netty.codec.http2.get()}")
+            force("io.netty:netty-codec:${libs.versions.netty.get()}")
+            force("io.netty:netty-codec-http:${libs.versions.netty.get()}")
+            force("io.netty:netty-codec-http2:${libs.versions.netty.get()}")
+            force("io.netty:netty-handler:${libs.versions.netty.get()}")
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ metalava = "0.5.0"
 kotlinx-serialization-json = "1.11.0"
 kotlinx-coroutines = "1.11.0"
 okio = "3.17.0"
-netty-codec-http2 = "4.1.132.Final"
+netty = "4.1.135.Final"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }


### PR DESCRIPTION
## What does this change?

Updates Netty to clear vuln alerts

## How to test

- Do a snapshot release
- Pull into the app
- Check it still works
