### PR TITLE
Force jackson version to fix CVEs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,8 @@ plugins {
 
 // Fix CVEs: CVE-2026-42583, CVE-2026-42584, CVE-2026-42587, CVE-2026-45416, CVE-2026-44249, CVE-2026-50010
 // Force all affected Netty artifacts to patched version (transitive via AGP)
+// Fix CVEs: CVE-2026-54512, CVE-2026-54513
+// Force jackson-databind and related artifacts to patched version (transitive via AGP/Kotlin tooling)
 allprojects {
     configurations.all {
         resolutionStrategy {
@@ -14,6 +16,9 @@ allprojects {
             force("io.netty:netty-codec-http:${libs.versions.netty.get()}")
             force("io.netty:netty-codec-http2:${libs.versions.netty.get()}")
             force("io.netty:netty-handler:${libs.versions.netty.get()}")
+            force("com.fasterxml.jackson.core:jackson-databind:${libs.versions.jackson.get()}")
+            force("com.fasterxml.jackson.core:jackson-core:${libs.versions.jackson.get()}")
+            force("com.fasterxml.jackson.core:jackson-annotations:${libs.versions.jackson.get()}")
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ kotlinx-serialization-json = "1.11.0"
 kotlinx-coroutines = "1.11.0"
 okio = "3.17.0"
 netty = "4.1.135.Final"
+jackson = "2.18.8"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }


### PR DESCRIPTION
## What does this change?

Forces the jackson-databind version to fix CVE alerts

## How to test

- Build a prerelease
- Check it doesn't break the apps

## How can we measure success?

Less CVEs and a happier system. Of course.

## Have we considered potential risks?

n/a, so long as it's tested....
