### PR TITLE
Fix CVE for bouncycastle

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
 
 // Fix CVEs: CVE-2026-42583, CVE-2026-42584, CVE-2026-42587, CVE-2026-45416, CVE-2026-44249, CVE-2026-50010
 // Force all affected Netty artifacts to patched version (transitive via AGP)
+// Fix CVE-2025-14813: force patched Bouncy Castle provider when pulled transitively.
 allprojects {
     configurations.all {
         resolutionStrategy {
@@ -14,6 +15,8 @@ allprojects {
             force("io.netty:netty-codec-http:${libs.versions.netty.get()}")
             force("io.netty:netty-codec-http2:${libs.versions.netty.get()}")
             force("io.netty:netty-handler:${libs.versions.netty.get()}")
+            force("org.bouncycastle:bcprov-jdk18on:${libs.versions.bouncycastle.get()}")
+            force("org.bouncycastle:bcprov-jdk15to18:${libs.versions.bouncycastle.get()}")
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ kotlinx-serialization-json = "1.11.0"
 kotlinx-coroutines = "1.11.0"
 okio = "3.17.0"
 netty = "4.1.135.Final"
+bouncycastle = "1.84"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }


### PR DESCRIPTION
## What does this change?

We got a vulnerability alert for a critical severity vulnerability, CVE-2025-14813, from [org.bouncycastle:bcprov-jdk18on](https://www.google.com/url?q=https://github.com/advisories/GHSA-574f-3g2m-x479&source=chat&ust=1783047685702000&usg=AOvVaw2H-9P-b0b7oPwKcQO0DPxj).

Analysis showed that this does not actually appear to be imported/used, but this PR introduces a safe floor for the library anyway

## How to test

- Build a prerelease
- Import into the Android app
- Make sure it works

## Have we considered potential risks?

Risk is negligible given that this does not appear to be used at runtime at all.
