### PR TITLE
Update Gradle release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ jobs:
   release:
     if: github.repository == 'guardian/feast-multiplatform-library'
     permissions: { contents: write, pull-requests: write }
-    uses: guardian/gha-gradle-library-release-workflow/.github/workflows/reusable-release.yml@f5240dec53346b509b908103aefda50ac560700c
+    uses: guardian/gha-gradle-library-release-workflow/.github/workflows/reusable-release.yml@1829c7a3152b70a65ab1e1f81ca44463f11708fb
     with:
       MODULES: 'library'
       API_FILE: 'api.txt'


### PR DESCRIPTION
## What does this change?

Updates the Gradle release workflow. The current version fails when the API file gets too long as the library's surface area increases. The update fixes that.

See the release workflow repo PR for more detail: https://github.com/guardian/gha-gradle-library-release-workflow/pull/12

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

I have started a test release from this branch here: https://github.com/guardian/feast-multiplatform-library/actions/runs/28940176067

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

