### PR TITLE
Supporting method for terminology conversion

### DIFF
--- a/library/src/commonMain/kotlin/com/gu/recipe/RenderRecipe.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/RenderRecipe.kt
@@ -277,6 +277,10 @@ class RenderSession(private val densityTable: DensityTable, private val terminol
         )
     }
 
+    fun applyTerminologyToRecipeTitle(title: String): String {
+        return replaceInText(title) ?: title
+    }
+
     private fun shouldConvert(section: TerminologySection, currentSection: TerminologySection): Boolean {
         return section == TerminologySection.ALL || section == currentSection
     }

--- a/library/src/commonMain/kotlin/com/gu/recipe/RenderRecipe.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/RenderRecipe.kt
@@ -278,7 +278,11 @@ class RenderSession(private val densityTable: DensityTable, private val terminol
     }
 
     fun applyTerminologyToRecipeTitle(title: String): String {
-        return replaceInText(title) ?: title
+        return if (convertTerminologies == false) {
+            title
+        } else {
+            replaceInText(title) ?: title
+        }
     }
 
     private fun shouldConvert(section: TerminologySection, currentSection: TerminologySection): Boolean {

--- a/library/src/commonTest/kotlin/com/gu/recipe/RenderRecipeTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/RenderRecipeTest.kt
@@ -626,6 +626,30 @@ class RenderRecipeTest {
     }
 
     @Test
+    fun `applyTerminologyToRecipeTitle converts just the right part of title`() {
+        val session = RenderSession(
+            densityTable = DensityTable(preparedAt = "none", HashMap(), HashMap()),
+            terminologyTable = com.gu.recipe.terminology.TerminologyTable(
+                terminologyMap = mapOf("aubergine" to "eggplant")
+            )
+        )
+
+        assertEquals("eggplant tart", session.applyTerminologyToRecipeTitle("aubergine tart"))
+    }
+
+    @Test
+    fun `applyTerminologyToRecipeTitle returns original title when conversion does not convert`() {
+        val session = RenderSession(
+            densityTable = DensityTable(preparedAt = "none", HashMap(), HashMap()),
+            terminologyTable = com.gu.recipe.terminology.TerminologyTable(
+                terminologyMap = mapOf("aubergine" to "eggplant")
+            )
+        )
+
+        assertEquals("eggplant tart", session.applyTerminologyToRecipeTitle("eggplant tart"))
+    }
+
+    @Test
     fun `replaceInText is case now sensitive and replaces whole terms with captilization of 1st letter if found so`() {
         val session = RenderSession(
             densityTable = DensityTable(preparedAt = "none", HashMap(), HashMap()),

--- a/library/src/commonTest/kotlin/com/gu/recipe/RenderRecipeTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/RenderRecipeTest.kt
@@ -631,10 +631,24 @@ class RenderRecipeTest {
             densityTable = DensityTable(preparedAt = "none", HashMap(), HashMap()),
             terminologyTable = com.gu.recipe.terminology.TerminologyTable(
                 terminologyMap = mapOf("aubergine" to "eggplant")
-            )
+            ),
+            convertTerminologies = true
         )
 
         assertEquals("eggplant tart", session.applyTerminologyToRecipeTitle("aubergine tart"))
+    }
+
+    @Test
+    fun `applyTerminologyToRecipeTitle returns original title when terminology conversion is disabled`() {
+        val session = RenderSession(
+            densityTable = DensityTable(preparedAt = "none", HashMap(), HashMap()),
+            terminologyTable = com.gu.recipe.terminology.TerminologyTable(
+                terminologyMap = mapOf("aubergine" to "eggplant")
+            ),
+            convertTerminologies = false
+        )
+
+        assertEquals("aubergine tart", session.applyTerminologyToRecipeTitle("aubergine tart"))
     }
 
     @Test


### PR DESCRIPTION
## What does this change?

This PR adds a small method to support terminology conversion for recipe card title, without requiring the full recipe body.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Unit tests

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

