### PR TITLE
Updated terminology replacement logic

### DIFF
--- a/library/src/commonMain/kotlin/com/gu/recipe/RenderRecipe.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/RenderRecipe.kt
@@ -277,8 +277,12 @@ class RenderSession(private val densityTable: DensityTable, private val terminol
         )
     }
 
-    fun applyTerminologyToRecipeTitle(title: String, measuringSystem: MeasuringSystem): String {
-        return if (convertTerminologies == true && measuringSystem == MeasuringSystem.USCombined) {
+    /**
+     * Applies terminology conversion to a recipe title for US combined measurements when enabled.
+     * Returns the original title when terminology conversion is disabled or not applicable.
+     */
+    fun applyTerminologyToRecipeTitle(title: String, targetMeasuringSystem: MeasuringSystem): String {
+        return if (convertTerminologies == true && targetMeasuringSystem == MeasuringSystem.USCombined) {
             applyTerminology(title) ?: title
         } else {
             title

--- a/library/src/commonMain/kotlin/com/gu/recipe/RenderRecipe.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/RenderRecipe.kt
@@ -240,12 +240,12 @@ class RenderSession(private val densityTable: DensityTable, private val terminol
     fun renderRecipeForTerminology(recipe: RecipeV3, section: TerminologySection = TerminologySection.ALL): RecipeV3 {
         return recipe.copy(
             title = if (shouldConvert(section, TerminologySection.TITLE)) {
-                replaceInText(recipe.title)
+                applyTerminology(recipe.title)
             } else {
                 recipe.title
             },
             description = if (shouldConvert(section, TerminologySection.DESCRIPTION)) {
-                replaceInText(recipe.description)
+                applyTerminology(recipe.description)
             } else {
                 recipe.description
             },
@@ -254,11 +254,11 @@ class RenderSession(private val densityTable: DensityTable, private val terminol
                     ingredientSection.copy(
                         ingredientsList = ingredientSection.ingredientsList?.map { ingredient ->
                             ingredient.copy(
-                                text = replaceInText(ingredient.text),
-                                template = replaceInText(ingredient.template)
+                                text = applyTerminology(ingredient.text),
+                                template = applyTerminology(ingredient.template)
                             )
                         },
-                        recipeSection = replaceInText(ingredientSection.recipeSection)
+                        recipeSection = applyTerminology(ingredientSection.recipeSection)
                     )
                 }
             } else {
@@ -267,8 +267,8 @@ class RenderSession(private val densityTable: DensityTable, private val terminol
             instructions = if (shouldConvert(section, TerminologySection.INSTRUCTIONS)) {
                 recipe.instructions?.map { instruction ->
                     instruction.copy(
-                        description = replaceInText(instruction.description) ?: instruction.description,
-                        descriptionTemplate = replaceInText(instruction.descriptionTemplate)
+                        description = applyTerminology(instruction.description) ?: instruction.description,
+                        descriptionTemplate = applyTerminology(instruction.descriptionTemplate)
                     )
                 }
             } else {
@@ -277,11 +277,11 @@ class RenderSession(private val densityTable: DensityTable, private val terminol
         )
     }
 
-    fun applyTerminologyToRecipeTitle(title: String): String {
-        return if (convertTerminologies == false) {
-            title
+    fun applyTerminologyToRecipeTitle(title: String, measuringSystem: MeasuringSystem): String {
+        return if (convertTerminologies == true && measuringSystem == MeasuringSystem.USCombined) {
+            applyTerminology(title) ?: title
         } else {
-            replaceInText(title) ?: title
+            title
         }
     }
 
@@ -289,7 +289,7 @@ class RenderSession(private val densityTable: DensityTable, private val terminol
         return section == TerminologySection.ALL || section == currentSection
     }
 
-    internal fun replaceInText(text: String?): String? {
+    internal fun applyTerminology(text: String?): String? {
         return terminologyTable?.convertTerm(text) ?: text
     }
 }

--- a/library/src/commonTest/kotlin/com/gu/recipe/RenderRecipeTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/RenderRecipeTest.kt
@@ -626,7 +626,7 @@ class RenderRecipeTest {
     }
 
     @Test
-    fun `applyTerminologyToRecipeTitle converts just the right part of title`() {
+    fun `applyTerminologyToRecipeTitle converts title when target measuring system is US and terminology conversion is enabled`() {
         val session = RenderSession(
             densityTable = DensityTable(preparedAt = "none", HashMap(), HashMap()),
             terminologyTable = com.gu.recipe.terminology.TerminologyTable(
@@ -635,11 +635,24 @@ class RenderRecipeTest {
             convertTerminologies = true
         )
 
-        assertEquals("eggplant tart", session.applyTerminologyToRecipeTitle("aubergine tart"))
+        assertEquals("eggplant tart", session.applyTerminologyToRecipeTitle("aubergine tart", MeasuringSystem.USCombined))
     }
 
     @Test
-    fun `applyTerminologyToRecipeTitle returns original title when terminology conversion is disabled`() {
+    fun `applyTerminologyToRecipeTitle returns original title when target measuring system is not US`() {
+        val session = RenderSession(
+            densityTable = DensityTable(preparedAt = "none", HashMap(), HashMap()),
+            terminologyTable = com.gu.recipe.terminology.TerminologyTable(
+                terminologyMap = mapOf("aubergine" to "eggplant")
+            ),
+            convertTerminologies = true
+        )
+
+        assertEquals("aubergine tart", session.applyTerminologyToRecipeTitle("aubergine tart", MeasuringSystem.Metric))
+    }
+
+    @Test
+    fun `applyTerminologyToRecipeTitle returns original title when terminology conversion is disabled for US measuring system`() {
         val session = RenderSession(
             densityTable = DensityTable(preparedAt = "none", HashMap(), HashMap()),
             terminologyTable = com.gu.recipe.terminology.TerminologyTable(
@@ -648,7 +661,7 @@ class RenderRecipeTest {
             convertTerminologies = false
         )
 
-        assertEquals("aubergine tart", session.applyTerminologyToRecipeTitle("aubergine tart"))
+        assertEquals("aubergine tart", session.applyTerminologyToRecipeTitle("aubergine tart", MeasuringSystem.USCustomary))
     }
 
     @Test
@@ -657,14 +670,15 @@ class RenderRecipeTest {
             densityTable = DensityTable(preparedAt = "none", HashMap(), HashMap()),
             terminologyTable = com.gu.recipe.terminology.TerminologyTable(
                 terminologyMap = mapOf("aubergine" to "eggplant")
-            )
+            ),
+            convertTerminologies = true
         )
 
-        assertEquals("eggplant tart", session.applyTerminologyToRecipeTitle("eggplant tart"))
+        assertEquals("eggplant tart", session.applyTerminologyToRecipeTitle("eggplant tart", MeasuringSystem.USCustomary))
     }
 
     @Test
-    fun `replaceInText is case now sensitive and replaces whole terms with captilization of 1st letter if found so`() {
+    fun `applyTerminology is case now sensitive and replaces whole terms with captilization of 1st letter if found so`() {
         val session = RenderSession(
             densityTable = DensityTable(preparedAt = "none", HashMap(), HashMap()),
             terminologyTable = com.gu.recipe.terminology.TerminologyTable(
@@ -672,12 +686,12 @@ class RenderRecipeTest {
             )
         )
 
-        assertEquals("Roast the Eggplant", session.replaceInText("Roast the AUBERGINE"))
-        assertEquals("aubergines are great", session.replaceInText("aubergines are great"))
+        assertEquals("Roast the Eggplant", session.applyTerminology("Roast the AUBERGINE"))
+        assertEquals("aubergines are great", session.applyTerminology("aubergines are great"))
     }
 
     @Test
-    fun `replaceInText prefers longer terminology matches before shorter ones`() {
+    fun `applyTerminology prefers longer terminology matches before shorter ones`() {
         val session = RenderSession(
             densityTable = DensityTable(preparedAt = "none", HashMap(), HashMap()),
             terminologyTable = com.gu.recipe.terminology.TerminologyTable(
@@ -688,7 +702,7 @@ class RenderRecipeTest {
             )
         )
 
-        assertEquals("powdered sugar", session.replaceInText("icing sugar"))
+        assertEquals("powdered sugar", session.applyTerminology("icing sugar"))
     }
 
     @Test


### PR DESCRIPTION
## What does this change?
This is update the `applyTerminologyToRecipeTitle` so it takes a measuring unit as input param so it can decide when to apply it - without that client was needing to check the logic in client side in many places. This is inline with how we do that with `renderRecipe` 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Unit test that make sure not to apply title conversion when target measuring unit is NOT `US`

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
By applying title conversion correctly.
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
No known risk, these logic may change in future but that is not limited to this method only.
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
