### PR TITLE
Graphql fronts test

### DIFF
--- a/core/api/build.gradle.kts
+++ b/core/api/build.gradle.kts
@@ -48,6 +48,7 @@ kotlin {
 
             // Specify CFBundleIdentifier to uniquely identify the framework
             binaryOption("bundleId", APIConfig.BUNDLE_ID)
+            export(project(":core:graphql"))
             xcf.add(this)
             isStatic = true
         }

--- a/core/api/build.gradle.kts
+++ b/core/api/build.gradle.kts
@@ -22,6 +22,14 @@ plugins {
     alias(libs.plugins.androidLibrary)
     alias(libs.plugins.metalava)
     alias(libs.plugins.kotlinSerialization)
+    id("co.touchlab.skie") version "0.10.13"
+}
+
+skie {
+    build {
+        produceDistributableFramework()
+        enableSwiftLibraryEvolution.set(true)
+    }
 }
 
 kotlin {

--- a/core/api/build.gradle.kts
+++ b/core/api/build.gradle.kts
@@ -60,7 +60,7 @@ kotlin {
             dependencies {
                 api(project(":core:networking"))
                 api(libs.koin.core)
-                implementation(project(":core:graphql"))
+                api(project(":core:graphql"))
                 implementation(libs.kotlinx.coroutines.core)
                 implementation(libs.kotlinx.serialization.json)
             }

--- a/core/api/src/commonMain/kotlin/com/gu/recipe/api/repository/GraphQlRecipeRepository.kt
+++ b/core/api/src/commonMain/kotlin/com/gu/recipe/api/repository/GraphQlRecipeRepository.kt
@@ -3,7 +3,7 @@ package com.gu.recipe.api.repository
 import com.gu.recipe.api.models.FrontResponse
 import com.gu.recipe.core.graphql.GraphQlError
 import com.gu.recipe.core.graphql.GraphQlResult
-import com.gu.recipe.core.graphql.generated.CurationQuery
+import com.gu.recipe.core.graphql.generated.CurationForTestQuery
 import com.gu.recipe.core.graphql.generated.GetFrontsByRegionQuery
 import com.gu.recipe.core.graphql.generated.type.Editions
 import com.gu.recipe.core.graphql.generated.type.Regions
@@ -36,7 +36,7 @@ class GraphQlRecipeRepository(
     override suspend fun getCurationForTest(
         region: Regions,
         edition: Editions
-    ): Result<CurationQuery.Data> {
+    ): Result<CurationForTestQuery.Data> {
         return when (val result = dataSource.getCurationForTest(
             region = region,
             edition = edition

--- a/core/api/src/commonMain/kotlin/com/gu/recipe/api/repository/GraphQlRecipeRepository.kt
+++ b/core/api/src/commonMain/kotlin/com/gu/recipe/api/repository/GraphQlRecipeRepository.kt
@@ -3,6 +3,7 @@ package com.gu.recipe.api.repository
 import com.gu.recipe.api.models.FrontResponse
 import com.gu.recipe.core.graphql.GraphQlError
 import com.gu.recipe.core.graphql.GraphQlResult
+import com.gu.recipe.core.graphql.generated.CurationQuery
 import com.gu.recipe.core.graphql.generated.GetFrontsByRegionQuery
 import com.gu.recipe.core.graphql.generated.type.Editions
 import com.gu.recipe.core.graphql.generated.type.Regions
@@ -28,6 +29,19 @@ class GraphQlRecipeRepository(
                 Result.success(front)
             }
 
+            is GraphQlResult.Failure -> Result.failure(result.error.toRepositoryError())
+        }
+    }
+
+    override suspend fun getCurationForTest(
+        region: Regions,
+        edition: Editions
+    ): Result<CurationQuery.Data> {
+        return when (val result = dataSource.getCurationForTest(
+            region = region,
+            edition = edition
+        )) {
+            is GraphQlResult.Success -> Result.success(result.value)
             is GraphQlResult.Failure -> Result.failure(result.error.toRepositoryError())
         }
     }

--- a/core/api/src/commonMain/kotlin/com/gu/recipe/api/repository/GraphQlRecipeRepository.kt
+++ b/core/api/src/commonMain/kotlin/com/gu/recipe/api/repository/GraphQlRecipeRepository.kt
@@ -54,11 +54,6 @@ class GraphQlRecipeRepository(
         is GraphQlError.Unexpected -> RecipeRepositoryError.Unexpected(cause)
         GraphQlError.MissingData -> RecipeRepositoryError.MissingData
     }
-
-    private fun GraphQlRecipe.toAPIResult(): FrontResponse =
-        FrontResponse(
-            id = id,
-        )
 }
 
 sealed class RecipeRepositoryError : Exception() {

--- a/core/api/src/commonMain/kotlin/com/gu/recipe/api/repository/GraphQlRecipeRepository.kt
+++ b/core/api/src/commonMain/kotlin/com/gu/recipe/api/repository/GraphQlRecipeRepository.kt
@@ -33,6 +33,7 @@ class GraphQlRecipeRepository(
         }
     }
 
+    @Throws(Exception::class)
     override suspend fun getCurationForTest(
         region: Regions,
         edition: Editions

--- a/core/api/src/commonMain/kotlin/com/gu/recipe/api/repository/GraphQlRecipeRepository.kt
+++ b/core/api/src/commonMain/kotlin/com/gu/recipe/api/repository/GraphQlRecipeRepository.kt
@@ -36,13 +36,13 @@ class GraphQlRecipeRepository(
     override suspend fun getCurationForTest(
         region: Regions,
         edition: Editions
-    ): Result<CurationForTestQuery.Data> {
+    ): CurationForTestQuery.Data {
         return when (val result = dataSource.getCurationForTest(
             region = region,
             edition = edition
         )) {
-            is GraphQlResult.Success -> Result.success(result.value)
-            is GraphQlResult.Failure -> Result.failure(result.error.toRepositoryError())
+            is GraphQlResult.Success -> result.value
+            is GraphQlResult.Failure -> throw result.error.toRepositoryError()
         }
     }
 

--- a/core/api/src/commonMain/kotlin/com/gu/recipe/api/repository/GraphQlRecipeRepository.kt
+++ b/core/api/src/commonMain/kotlin/com/gu/recipe/api/repository/GraphQlRecipeRepository.kt
@@ -9,6 +9,7 @@ import com.gu.recipe.core.graphql.generated.type.Editions
 import com.gu.recipe.core.graphql.generated.type.Regions
 import com.gu.recipe.core.graphql.model.GraphQlRecipe
 import com.gu.recipe.core.graphql.repository.RecipeGraphQlDataSource
+import kotlin.coroutines.cancellation.CancellationException
 
 class GraphQlRecipeRepository(
     private val dataSource: RecipeGraphQlDataSource,
@@ -33,7 +34,7 @@ class GraphQlRecipeRepository(
         }
     }
 
-    @Throws(Exception::class)
+    @Throws(RecipeRepositoryError::class, CancellationException::class)
     override suspend fun getCurationForTest(
         region: Regions,
         edition: Editions

--- a/core/api/src/commonMain/kotlin/com/gu/recipe/api/repository/RecipeRepository.kt
+++ b/core/api/src/commonMain/kotlin/com/gu/recipe/api/repository/RecipeRepository.kt
@@ -1,6 +1,6 @@
 package com.gu.recipe.api.repository
 
-import com.gu.recipe.core.graphql.generated.CurationQuery
+import com.gu.recipe.core.graphql.generated.CurationForTestQuery
 import com.gu.recipe.core.graphql.generated.GetFrontsByRegionQuery
 import com.gu.recipe.core.graphql.generated.type.Editions
 import com.gu.recipe.core.graphql.generated.type.Regions
@@ -15,5 +15,5 @@ interface RecipeRepository {
     suspend fun getCurationForTest(
         region: Regions,
         edition: Editions
-    ): Result<CurationQuery.Data>
+    ): Result<CurationForTestQuery.Data>
 }

--- a/core/api/src/commonMain/kotlin/com/gu/recipe/api/repository/RecipeRepository.kt
+++ b/core/api/src/commonMain/kotlin/com/gu/recipe/api/repository/RecipeRepository.kt
@@ -12,6 +12,7 @@ interface RecipeRepository {
         recipesLimit: Int
     ): Result<List<GetFrontsByRegionQuery.Front>>
 
+    @Throws(Exception::class)
     suspend fun getCurationForTest(
         region: Regions,
         edition: Editions

--- a/core/api/src/commonMain/kotlin/com/gu/recipe/api/repository/RecipeRepository.kt
+++ b/core/api/src/commonMain/kotlin/com/gu/recipe/api/repository/RecipeRepository.kt
@@ -1,5 +1,6 @@
 package com.gu.recipe.api.repository
 
+import com.gu.recipe.core.graphql.generated.CurationQuery
 import com.gu.recipe.core.graphql.generated.GetFrontsByRegionQuery
 import com.gu.recipe.core.graphql.generated.type.Editions
 import com.gu.recipe.core.graphql.generated.type.Regions
@@ -10,4 +11,9 @@ interface RecipeRepository {
         edition: Editions,
         recipesLimit: Int
     ): Result<List<GetFrontsByRegionQuery.Front>>
+
+    suspend fun getCurationForTest(
+        region: Regions,
+        edition: Editions
+    ): Result<CurationQuery.Data>
 }

--- a/core/api/src/commonMain/kotlin/com/gu/recipe/api/repository/RecipeRepository.kt
+++ b/core/api/src/commonMain/kotlin/com/gu/recipe/api/repository/RecipeRepository.kt
@@ -15,5 +15,5 @@ interface RecipeRepository {
     suspend fun getCurationForTest(
         region: Regions,
         edition: Editions
-    ): Result<CurationForTestQuery.Data>
+    ): CurationForTestQuery.Data
 }

--- a/core/api/src/commonMain/kotlin/com/gu/recipe/api/repository/RecipeRepository.kt
+++ b/core/api/src/commonMain/kotlin/com/gu/recipe/api/repository/RecipeRepository.kt
@@ -4,6 +4,7 @@ import com.gu.recipe.core.graphql.generated.CurationForTestQuery
 import com.gu.recipe.core.graphql.generated.GetFrontsByRegionQuery
 import com.gu.recipe.core.graphql.generated.type.Editions
 import com.gu.recipe.core.graphql.generated.type.Regions
+import kotlin.coroutines.cancellation.CancellationException
 
 interface RecipeRepository {
     suspend fun getFrontByRegion(
@@ -12,7 +13,7 @@ interface RecipeRepository {
         recipesLimit: Int
     ): Result<List<GetFrontsByRegionQuery.Front>>
 
-    @Throws(Exception::class)
+    @Throws(RecipeRepositoryError::class, CancellationException::class)
     suspend fun getCurationForTest(
         region: Regions,
         edition: Editions

--- a/core/api/src/commonTest/kotlin/com/gu/recipe/api/repository/GraphQlRecipeRepositoryTest.kt
+++ b/core/api/src/commonTest/kotlin/com/gu/recipe/api/repository/GraphQlRecipeRepositoryTest.kt
@@ -1,7 +1,7 @@
 package com.gu.recipe.api.repository
 
 import com.gu.recipe.core.graphql.GraphQlResult
-import com.gu.recipe.core.graphql.generated.CurationQuery
+import com.gu.recipe.core.graphql.generated.CurationForTestQuery
 import com.gu.recipe.core.graphql.generated.GetFrontsByRegionQuery
 import com.gu.recipe.core.graphql.generated.type.Editions
 import com.gu.recipe.core.graphql.generated.type.Regions
@@ -9,7 +9,7 @@ import com.gu.recipe.core.graphql.repository.RecipeGraphQlDataSource
 
 private class FakeRecipeGraphQlDataSource(
     private val result: GraphQlResult<List<GetFrontsByRegionQuery.Front>>? = null,
-    private val curationResult: GraphQlResult<CurationQuery.Data>? = null
+    private val curationResult: GraphQlResult<CurationForTestQuery.Data>? = null
 ) : RecipeGraphQlDataSource {
 
     override suspend fun getFrontByRegion(
@@ -21,7 +21,7 @@ private class FakeRecipeGraphQlDataSource(
     override suspend fun getCurationForTest(
         region: Regions,
         edition: Editions
-    ): GraphQlResult<CurationQuery.Data> = curationResult!!
+    ): GraphQlResult<CurationForTestQuery.Data> = curationResult!!
 }
 
 private fun suspendTest(block: suspend () -> Unit) {

--- a/core/api/src/commonTest/kotlin/com/gu/recipe/api/repository/GraphQlRecipeRepositoryTest.kt
+++ b/core/api/src/commonTest/kotlin/com/gu/recipe/api/repository/GraphQlRecipeRepositoryTest.kt
@@ -1,20 +1,27 @@
 package com.gu.recipe.api.repository
 
 import com.gu.recipe.core.graphql.GraphQlResult
+import com.gu.recipe.core.graphql.generated.CurationQuery
 import com.gu.recipe.core.graphql.generated.GetFrontsByRegionQuery
 import com.gu.recipe.core.graphql.generated.type.Editions
 import com.gu.recipe.core.graphql.generated.type.Regions
 import com.gu.recipe.core.graphql.repository.RecipeGraphQlDataSource
 
 private class FakeRecipeGraphQlDataSource(
-    private val result: GraphQlResult<List<GetFrontsByRegionQuery.Front>>,
+    private val result: GraphQlResult<List<GetFrontsByRegionQuery.Front>>? = null,
+    private val curationResult: GraphQlResult<CurationQuery.Data>? = null
 ) : RecipeGraphQlDataSource {
 
     override suspend fun getFrontByRegion(
         region: Regions,
         edition: Editions,
         recipesLimit: Int
-    ): GraphQlResult<List<GetFrontsByRegionQuery.Front>> = result
+    ): GraphQlResult<List<GetFrontsByRegionQuery.Front>> = result!!
+
+    override suspend fun getCurationForTest(
+        region: Regions,
+        edition: Editions
+    ): GraphQlResult<CurationQuery.Data> = curationResult!!
 }
 
 private fun suspendTest(block: suspend () -> Unit) {

--- a/core/graphql/src/commonMain/graphql/CurationForTest.graphql
+++ b/core/graphql/src/commonMain/graphql/CurationForTest.graphql
@@ -1,0 +1,31 @@
+query Curation($region: regions!, $edition: editions!) {
+    curation(region: $region, edition: $edition) {
+        title
+        items {
+            ... on RecipeReference {
+                recipe {
+                    appExclusiveBranding
+                    title
+                    contributors {
+                        webTitle
+                    }
+                    featuredImage {
+                        templateUrl
+                        url
+                    }
+                    diets
+                    renderedTimings
+                }
+            }
+            ... on Chef {
+                chef {
+                    foregroundHex
+                    backgroundHex
+                    image
+                    id
+                    bio
+                }
+            }
+        }
+    }
+}

--- a/core/graphql/src/commonMain/graphql/CurationForTest.graphql
+++ b/core/graphql/src/commonMain/graphql/CurationForTest.graphql
@@ -5,6 +5,7 @@ query CurationForTest($region: regions!, $edition: editions!) {
             ... on RecipeReference {
                 recipe {
                     appExclusiveBranding
+                    id
                     title
                     contributors {
                         webTitle

--- a/core/graphql/src/commonMain/graphql/CurationForTest.graphql
+++ b/core/graphql/src/commonMain/graphql/CurationForTest.graphql
@@ -1,4 +1,4 @@
-query Curation($region: regions!, $edition: editions!) {
+query CurationForTest($region: regions!, $edition: editions!) {
     curation(region: $region, edition: $edition) {
         title
         items {

--- a/core/graphql/src/commonMain/graphql/schema.graphqls
+++ b/core/graphql/src/commonMain/graphql/schema.graphqls
@@ -1,5 +1,8 @@
-schema {
-  query: Query
+enum AppColour {
+  Primary
+  Quaternary
+  Secondary
+  Tertiary
 }
 
 type Chef {
@@ -45,18 +48,58 @@ enum ContentTypes {
   RECIPE
 }
 
+type CustomMessage {
+  backgroundColor: AppColour!
+  ctaLabel: String
+  foregroundColor: AppColour!
+  image: String!
+  isDismissable: Boolean!
+  isIcon: Boolean!
+  showChevron: Boolean!
+  size: PromptSize!
+  supporting: String
+  title: String!
+}
+
+type CustomMessageInsert {
+  messages: [CustomMessage!]!
+}
+
 type FeastAppContainer {
   body: String
   excludedRegions: [String!]
-  id: uuid
+  id: uuid!
   identityId: String
   items: [item!]!
   targetedRegions: [String!]
   title: String!
 }
 
+type Insert {
+  "What type of insert this is, indicating the content to be shown"
+  insertType: String!
+}
+
+type KeywordStats {
+  buckets: [StatBucket!]!
+  docCountErrorUpperBound: Int!
+  sumOtherDocCount: Int!
+}
+
+type KeywordSuggestionsInsert {
+  keywordSuggestions: [SuggestedFilterResult!]!
+}
+
 "A timestamp in local format"
 scalar LocalDateTime
+
+"The original measuring system used in this recipe"
+enum OriginalMeasuringSystem {
+  AUS
+  IMPERIAL
+  METRIC
+  US
+}
 
 type Palette {
   backgroundHex: String
@@ -73,9 +116,15 @@ type PrivateNote {
   recipeId: String!
 }
 
+enum PromptSize {
+  large
+  small
+}
+
 type Query {
   "Items saved in the current user's personal collections"
   SavedCollections: [SavedCollection!]!
+  availableFilters: availableFilters!
 
   "information about a specific chef"
   chef(id: String!): ChefBio
@@ -86,20 +135,21 @@ type Query {
   "returns curation ('fronts') information"
   curation(region: regions!, edition: editions!, date: date): [FeastAppContainer!]!
 
-  "returns a recipe with specific checksum"
-  recipe(checksum: String!): Recipe
-
-  "returns a recipe with the specific id and version"
-  recipeById(id: String!): Recipe
+  "returns a recipe with the specific unique id"
+  recipe(id: String!): Recipe
 
   "returns all recipes"
   recipes(limit: Int!, offset: Int, sortBy: recipeSortFields, sortDirection: recipeSortDirections, celebrations: [String!], cuisines: [String!], diets: [String!], mealTypes: [String!], techniques: [String!], utensilsAppliances: [String!], contributors: [String!], bylines: [String!]): [Recipe!]!
+
+  "performs a recipe search and returns the results"
+  search(pageSize: Int, page: Int, uprateByDate: SortableDates, cuisineFilter: [String!], contributorFilter: [String!], dietFilter: [String!], mealTypeFilter: [String!], celebrationFilter: [String!], sponsorFilter: [String!], enableCutOff: Boolean, q: String!, limit: Int): SearchResponse
 }
 
 "A field containing a raw JSON object"
 scalar RawJson
 
 type Recipe {
+  appExclusiveBranding: Boolean!
   bookCredit: String
   canonicalArticle: String
 
@@ -132,8 +182,10 @@ type Recipe {
 
   "Meal type IDs associated with this recipe"
   mealTypes: [String!]!
+  originalMeasuringSystem: OriginalMeasuringSystem!
   previewImage: image
   publishedDate: LocalDateTime
+  renderedTimings: String
 
   "The number of people who've saved this recipe"
   savedByCount: Int!
@@ -143,7 +195,7 @@ type Recipe {
   serves: [serving!]!
 
   "Sponsorship entries associated with this recipe"
-  sponsorships: [RawJson!]!
+  sponsorships: [SponsorData!]!
 
   "Technique IDs associated with this recipe"
   techniques: [String!]!
@@ -191,6 +243,61 @@ type SavedRecipe {
   recipe: Recipe
 }
 
+type SearchHit {
+  "a referenced recipe"
+  recipe: Recipe!
+
+  "Score of the result. The higher the number, the more relevant the result. Generally between 0 and 1"
+  score: Float
+}
+
+type SearchResponse {
+  maxScore: Float!
+
+  "The results of the search"
+  results: [SearchResult!]!
+  stats: StatsSection
+}
+
+union SearchResult = SearchHit | Insert | KeywordSuggestionsInsert | CustomMessageInsert
+
+"Specific date fields that can be used for reordering results"
+enum SortableDates {
+  "The first time that this recipe (article) was published"
+  firstPublishedDate
+
+  "The last time a change was made to the block containing this recipe in its original article"
+  lastModifiedDate
+
+  "The last time a revision of the recipe (article) was published"
+  publishedDate
+}
+
+type SponsorData {
+  highContrastSponsorLogo: String
+  highContrastSponsorLogoHeight: Int
+  highContrastSponsorLogoWidth: Int
+  sponsorLink: String!
+  sponsorLogo: String!
+  sponsorLogoHeight: Int
+  sponsorLogoWidth: Int
+  sponsorName: String!
+  sponsorshipType: String!
+}
+
+type StatBucket {
+  docCount: Int!
+  key: String!
+}
+
+type StatsSection {
+  bylines: KeywordStats
+  contributors: KeywordStats
+  cuisineIds: KeywordStats
+  mealTypeIds: KeywordStats
+  suitableForDietIds: KeywordStats
+}
+
 type SubCollection {
   collection: SubCollectionData!
 }
@@ -207,8 +314,50 @@ type SubCollectionData {
   title: String!
 }
 
+type SuggestedContributor {
+  "Information about this chef"
+  chef: ChefBio
+  id: String!
+  type: SuggestedFilterType!
+}
+
+type SuggestedFilter {
+  id: String!
+  type: SuggestedFilterType!
+}
+
+"Represents a filter that the user might want to apply. If a contributor it allows the whole of the contributor's information"
+union SuggestedFilterResult = SuggestedContributor | SuggestedFilter
+
+enum SuggestedFilterType {
+  Byline
+  Celebration
+  Contributor
+  Cuisine
+  MealType
+  SuitableForDiet
+}
+
 "A timestamp with timezone attached"
 scalar ZonedDateTime
+
+"shows which values are available for search filtering in each category"
+type availableFilters {
+  "collects recipes best suited to certain occasions, for example Christmas"
+  celebrationIds(startAt: Int = 0, limit: Int = 20): [String!]!
+
+  "collects recipes by our main chefs. For more options see the `chef` root query type"
+  contributorIds(startAt: Int = 0, limit: Int = 20, contains: String): [String!]!
+
+  "collects recipes by their geographical origin"
+  cuisineIds(startAt: Int = 0, limit: Int = 20): [String!]!
+
+  "which diets a recipe is suitable for, for example vegetarian"
+  dietIds(startAt: Int = 0, limit: Int = 20): [String!]!
+
+  "collects recipes by the part of a meal they are best suited for, for example starter or main course"
+  mealTypeIds(startAt: Int = 0, limit: Int = 20): [String!]!
+}
 
 type byline {
   "returns all recipes"

--- a/core/graphql/src/commonMain/kotlin/com/gu/recipe/core/graphql/repository/ApolloRecipeGraphQlDataSource.kt
+++ b/core/graphql/src/commonMain/kotlin/com/gu/recipe/core/graphql/repository/ApolloRecipeGraphQlDataSource.kt
@@ -3,7 +3,7 @@ package com.gu.recipe.core.graphql.repository
 import com.gu.recipe.core.graphql.GraphQlResult
 import com.gu.recipe.core.graphql.client.FeastGraphQlClient
 import com.gu.recipe.core.graphql.generated.GetFrontsByRegionQuery
-import com.gu.recipe.core.graphql.generated.CurationForTestQuery
+import com.gu.recipe.core.graphql.generated.CurationQuery
 import com.gu.recipe.core.graphql.generated.type.Editions
 import com.gu.recipe.core.graphql.generated.type.Regions
 
@@ -29,9 +29,9 @@ class ApolloRecipeGraphQlDataSource(
     override suspend fun getCurationForTest(
         region: Regions,
         edition: Editions
-    ): GraphQlResult<List<CurationForTest.Front>> {
+    ): GraphQlResult<CurationQuery.Data> {
         return when (val result = feastGraphQlClient.query(
-            CurationForTestQuery(
+            CurationQuery(
                 region = region,
                 edition = edition
             )

--- a/core/graphql/src/commonMain/kotlin/com/gu/recipe/core/graphql/repository/ApolloRecipeGraphQlDataSource.kt
+++ b/core/graphql/src/commonMain/kotlin/com/gu/recipe/core/graphql/repository/ApolloRecipeGraphQlDataSource.kt
@@ -3,6 +3,7 @@ package com.gu.recipe.core.graphql.repository
 import com.gu.recipe.core.graphql.GraphQlResult
 import com.gu.recipe.core.graphql.client.FeastGraphQlClient
 import com.gu.recipe.core.graphql.generated.GetFrontsByRegionQuery
+import com.gu.recipe.core.graphql.generated.CurationForTestQuery
 import com.gu.recipe.core.graphql.generated.type.Editions
 import com.gu.recipe.core.graphql.generated.type.Regions
 
@@ -21,6 +22,21 @@ class ApolloRecipeGraphQlDataSource(
             )
         )) {
             is GraphQlResult.Success -> GraphQlResult.Success(result.value.Front)
+            is GraphQlResult.Failure -> result
+        }
+    }
+
+    override suspend fun getCurationForTest(
+        region: Regions,
+        edition: Editions
+    ): GraphQlResult<List<CurationForTest.Front>> {
+        return when (val result = feastGraphQlClient.query(
+            CurationForTestQuery(
+                region = region,
+                edition = edition
+            )
+        )) {
+            is GraphQlResult.Success -> GraphQlResult.Success(result.value)
             is GraphQlResult.Failure -> result
         }
     }

--- a/core/graphql/src/commonMain/kotlin/com/gu/recipe/core/graphql/repository/ApolloRecipeGraphQlDataSource.kt
+++ b/core/graphql/src/commonMain/kotlin/com/gu/recipe/core/graphql/repository/ApolloRecipeGraphQlDataSource.kt
@@ -3,7 +3,7 @@ package com.gu.recipe.core.graphql.repository
 import com.gu.recipe.core.graphql.GraphQlResult
 import com.gu.recipe.core.graphql.client.FeastGraphQlClient
 import com.gu.recipe.core.graphql.generated.GetFrontsByRegionQuery
-import com.gu.recipe.core.graphql.generated.CurationQuery
+import com.gu.recipe.core.graphql.generated.CurationForTestQuery
 import com.gu.recipe.core.graphql.generated.type.Editions
 import com.gu.recipe.core.graphql.generated.type.Regions
 
@@ -29,9 +29,9 @@ class ApolloRecipeGraphQlDataSource(
     override suspend fun getCurationForTest(
         region: Regions,
         edition: Editions
-    ): GraphQlResult<CurationQuery.Data> {
+    ): GraphQlResult<CurationForTestQuery.Data> {
         return when (val result = feastGraphQlClient.query(
-            CurationQuery(
+            CurationForTestQuery(
                 region = region,
                 edition = edition
             )

--- a/core/graphql/src/commonMain/kotlin/com/gu/recipe/core/graphql/repository/RecipeGraphQlDataSource.kt
+++ b/core/graphql/src/commonMain/kotlin/com/gu/recipe/core/graphql/repository/RecipeGraphQlDataSource.kt
@@ -2,7 +2,7 @@ package com.gu.recipe.core.graphql.repository
 
 import com.gu.recipe.core.graphql.GraphQlResult
 import com.gu.recipe.core.graphql.generated.GetFrontsByRegionQuery
-import com.gu.recipe.core.graphql.generated.CurationQuery
+import com.gu.recipe.core.graphql.generated.CurationForTestQuery
 import com.gu.recipe.core.graphql.generated.type.Editions
 import com.gu.recipe.core.graphql.generated.type.Regions
 
@@ -16,5 +16,5 @@ interface RecipeGraphQlDataSource {
     suspend fun getCurationForTest(
         region: Regions,
         edition: Editions
-    ): GraphQlResult<CurationQuery.Data>
+    ): GraphQlResult<CurationForTestQuery.Data>
 }

--- a/core/graphql/src/commonMain/kotlin/com/gu/recipe/core/graphql/repository/RecipeGraphQlDataSource.kt
+++ b/core/graphql/src/commonMain/kotlin/com/gu/recipe/core/graphql/repository/RecipeGraphQlDataSource.kt
@@ -2,7 +2,7 @@ package com.gu.recipe.core.graphql.repository
 
 import com.gu.recipe.core.graphql.GraphQlResult
 import com.gu.recipe.core.graphql.generated.GetFrontsByRegionQuery
-import com.gu.recipe.core.graphql.generated.CurationForTestQuery
+import com.gu.recipe.core.graphql.generated.CurationQuery
 import com.gu.recipe.core.graphql.generated.type.Editions
 import com.gu.recipe.core.graphql.generated.type.Regions
 
@@ -16,5 +16,5 @@ interface RecipeGraphQlDataSource {
     suspend fun getCurationForTest(
         region: Regions,
         edition: Editions
-    ): GraphQlResult<List<CurationForTest.Front>>
+    ): GraphQlResult<CurationQuery.Data>
 }

--- a/core/graphql/src/commonMain/kotlin/com/gu/recipe/core/graphql/repository/RecipeGraphQlDataSource.kt
+++ b/core/graphql/src/commonMain/kotlin/com/gu/recipe/core/graphql/repository/RecipeGraphQlDataSource.kt
@@ -2,6 +2,7 @@ package com.gu.recipe.core.graphql.repository
 
 import com.gu.recipe.core.graphql.GraphQlResult
 import com.gu.recipe.core.graphql.generated.GetFrontsByRegionQuery
+import com.gu.recipe.core.graphql.generated.CurationForTestQuery
 import com.gu.recipe.core.graphql.generated.type.Editions
 import com.gu.recipe.core.graphql.generated.type.Regions
 
@@ -11,4 +12,9 @@ interface RecipeGraphQlDataSource {
         edition: Editions,
         recipesLimit: Int,
     ): GraphQlResult<List<GetFrontsByRegionQuery.Front>>
+
+    suspend fun getCurationForTest(
+        region: Regions,
+        edition: Editions
+    ): GraphQlResult<List<CurationForTest.Front>>
 }


### PR DESCRIPTION
> [!WARNING]
> This PR is not intended for immediate merge and is not based off main. 
> It's intended to show the current process for adding a query and to isolate testing work from the POC cleanup

## What does this change?

- Updates the graphql schema, taking into account https://github.com/guardian/feast-unified-api/pull/22 and https://github.com/guardian/feast-unified-api/pull/14
- Adds the "fetch curation" query we developed together as a group (requires https://github.com/guardian/feast-unified-api/pull/29 on the server side to work)
- Exposes via a new function `getCurationForTest` on `recipeRepository`

## How to test

- Get this branch locally
- Build the xcframeworks for iOS (@tkgnm or @shamoon-guardian can you fill in the steps to do this?)
- Link into the iOS project, set up the library to point to CODE
- Ensure that https://github.com/guardian/feast-unified-api/pull/29 is deployed to CODE
- Test it

## How can we measure success?

Able to conduct further integration testing on iOS, to understand the scale of work to bring the data out to the render layer

## Have we considered potential risks?

n/a