### PR TITLE
Add substitution as guidance notes fields for uk and us terms

### DIFF
--- a/library/src/commonMain/kotlin/com/gu/recipe/RenderRecipe.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/RenderRecipe.kt
@@ -271,7 +271,9 @@ class RenderSession(private val densityTable: DensityTable, private val terminol
                             ingredient.copy(
                                 text = applyTerminology(ingredient.text),
                                 ingredientWithoutSuffix = applyTerminology(ingredient.ingredientWithoutSuffix),
-                                template = applyTerminology(ingredient.template)
+                                template = applyTerminology(ingredient.template),
+                                ukGuidance = getUkGuidanceForUkTerm(ingredient.text), // Pass the ukGuidance to the ingredient
+                                usGuidance = null
                             )
                         },
                         recipeSection = applyTerminology(ingredientSection.recipeSection)
@@ -293,13 +295,14 @@ class RenderSession(private val densityTable: DensityTable, private val terminol
         )
     }
 
+
     /**
      * Applies terminology conversion to a recipe title for US combined measurements when enabled.
      * Returns the original title when terminology conversion is disabled or not applicable.
      */
     fun applyTerminologyToRecipeTitle(title: String, targetMeasuringSystem: MeasuringSystem): String {
         return if (convertTerminologies == true && targetMeasuringSystem == MeasuringSystem.USCombined) {
-            applyTerminology(title) ?: title
+            terminologyTable?.convertTerm(title)?.replacedString ?: title
         } else {
             title
         }
@@ -310,8 +313,31 @@ class RenderSession(private val densityTable: DensityTable, private val terminol
     }
 
     internal fun applyTerminology(text: String?): String? {
-        return terminologyTable?.convertTerm(text) ?: text
+        println("applyTerminology: Input text='$text'")
+        val result = terminologyTable?.convertTerm(text)?.replacedString ?: text
+        println("applyTerminology: Result='$result'")
+        return result
     }
+    /**
+     * Retrieves the ukGuidance associated with a given ukTerm.
+     *
+     * @param ukTerm The UK term to look up in the terminology table.
+     * @return The associated ukGuidance string, or null if not found.
+     */
+    fun getUkGuidanceForUkTerm(ukTerm: String?): String? {
+        println("getUkGuidanceForUkTerm: Input ukTerm='$ukTerm'")
+        if (ukTerm.isNullOrBlank()) {
+            println("getUkGuidanceForUkTerm: ukTerm is null or blank")
+            return null
+        }
+        val result = terminologyTable?.convertTerm(ukTerm)
+        println("getUkGuidanceForUkTerm: Retrieved ukGuidance='${result?.terminologyEntry?.ukGuidance}'")
+        return result?.terminologyEntry?.ukGuidance
+    }
+
+
+
+
 }
 
 fun newRenderSession(rawDensityData: String? = null, rawTerminologyData: String? = null, convertTerminologies: Boolean? = null): Result<RenderSession> {

--- a/library/src/commonMain/kotlin/com/gu/recipe/RenderRecipe.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/RenderRecipe.kt
@@ -272,8 +272,8 @@ class RenderSession(private val densityTable: DensityTable, private val terminol
                                 text = applyTerminology(ingredient.text),
                                 ingredientWithoutSuffix = applyTerminology(ingredient.ingredientWithoutSuffix),
                                 template = applyTerminology(ingredient.template),
-                                ukGuidance = getUkGuidanceForUkTerm(ingredient.text), // Pass the ukGuidance to the ingredient
-                                usGuidance = null
+                                ukGuidance = getGuidanceForTerm(ingredient.text, "uk"), // Pass the ukGuidance to the ingredient
+                                usGuidance = getGuidanceForTerm(ingredient.text, "us")
                             )
                         },
                         recipeSection = applyTerminology(ingredientSection.recipeSection)
@@ -318,21 +318,28 @@ class RenderSession(private val densityTable: DensityTable, private val terminol
         println("applyTerminology: Result='$result'")
         return result
     }
+
     /**
-     * Retrieves the ukGuidance associated with a given ukTerm.
+     * Retrieves the guidance associated with a given term based on the country code.
      *
-     * @param ukTerm The UK term to look up in the terminology table.
-     * @return The associated ukGuidance string, or null if not found.
+     * @param term The term to look up in the terminology table.
+     * @param countryCode The country code ("uk" or "us") to determine which guidance to retrieve.
+     * @return The associated guidance string, or null if not found.
      */
-    fun getUkGuidanceForUkTerm(ukTerm: String?): String? {
-        println("getUkGuidanceForUkTerm: Input ukTerm='$ukTerm'")
-        if (ukTerm.isNullOrBlank()) {
-            println("getUkGuidanceForUkTerm: ukTerm is null or blank")
+    fun getGuidanceForTerm(term: String?, countryCode: String): String? {
+        println("getGuidanceForTerm: Input term='$term', countryCode='$countryCode'")
+        if (term.isNullOrBlank()) {
+            println("getGuidanceForTerm: term is null or blank")
             return null
         }
-        val result = terminologyTable?.convertTerm(ukTerm)
-        println("getUkGuidanceForUkTerm: Retrieved ukGuidance='${result?.terminologyEntry?.ukGuidance}'")
-        return result?.terminologyEntry?.ukGuidance
+        val result = terminologyTable?.convertTerm(term)
+        val guidance = when (countryCode.lowercase()) {
+            "uk" -> result?.terminologyEntry?.ukGuidance
+            "us" -> result?.terminologyEntry?.usGuidance
+            else -> null
+        }
+        println("getGuidanceForTerm: Retrieved guidance='$guidance'")
+        return guidance
     }
 
 

--- a/library/src/commonMain/kotlin/com/gu/recipe/generated/RecipeModels.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/generated/RecipeModels.kt
@@ -269,7 +269,17 @@ data class IngredientItem (
     /**
      * Unit of measurement for the ingredient
      */
-    val unit: String? = null
+    val unit: String? = null,
+
+    /**
+     * Guidance notes for any UK term to highlight the context
+     */
+    val ukGuidance: String? = null,
+
+    /**
+     * Guidance notes for any US term to highlight the context
+     */
+    val usGuidance: String? = null
 )
 
 /**

--- a/library/src/commonMain/kotlin/com/gu/recipe/generated/TerminologyFixture.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/generated/TerminologyFixture.kt
@@ -2,713 +2,1163 @@
 package com.gu.recipe.generated
 
 val internalTerminologyData = """{
-  "prepared_at": "2026-07-17T14:17:40.492Z",
+  "prepared_at": "2026-07-23T14:33:07.361Z",
   "key": [
     "id",
     "ukTerm",
     "usTerm",
-    "block"
+    "block",
+    "ukGuidance",
+    "usGuidance"
   ],
   "values": [
     [
       1,
       "aubergine",
       "eggplant",
-      []
+      [
+        "eggplant"
+      ],
+      "Testing uk guidance notes for aubergine",
+      "Testing us guidance notes for eggplant"
     ],
     [
       2,
       "aubergines",
       "eggplants",
-      []
+      [
+        "eggplants"
+      ],
+      "",
+      ""
     ],
     [
       3,
       "streaky bacon",
       "American bacon",
-      []
+      [
+        "American bacon"
+      ],
+      "",
+      ""
     ],
     [
       4,
       "back bacon",
       "Canadian bacon",
-      []
+      [
+        "Canadian bacon"
+      ],
+      "",
+      ""
     ],
     [
       5,
       "square pan",
       "pan",
-      []
+      [
+        "pan"
+      ],
+      "",
+      ""
     ],
     [
       6,
       "loaf tin",
       "loaf pan",
-      []
+      [
+        "loaf pan"
+      ],
+      "",
+      ""
     ],
     [
       7,
       "banana shallots",
       "shallots",
-      []
+      [
+        "shallots"
+      ],
+      "",
+      ""
     ],
     [
       8,
       "bavette",
       "flap steak",
-      []
+      [
+        "flap steak"
+      ],
+      "",
+      ""
     ],
     [
       9,
       "beef mince",
       "ground beef",
-      []
+      [
+        "ground beef"
+      ],
+      "",
+      ""
     ],
     [
       10,
       "beetroot",
       "beets",
-      []
+      [
+        "beets"
+      ],
+      "",
+      ""
     ],
     [
       11,
       "bicarbonate of soda",
       "baking soda",
-      []
+      [
+        "baking soda"
+      ],
+      "",
+      ""
     ],
     [
       12,
       "Biscoff",
       "cookie butter",
-      []
+      [
+        "cookie butter"
+      ],
+      "",
+      ""
     ],
     [
       13,
       "blackcurrants",
       "berries",
-      []
+      [
+        "berries"
+      ],
+      "",
+      ""
     ],
     [
       14,
       "black-eyed beans",
       "black-eyed peas",
-      []
+      [
+        "black-eyed peas"
+      ],
+      "",
+      ""
     ],
     [
       15,
       "borlotti beans",
       "cranberry beans",
-      []
+      [
+        "cranberry beans"
+      ],
+      "",
+      ""
     ],
     [
       16,
       "braising steak",
       "stew beef",
-      []
+      [
+        "stew beef"
+      ],
+      "",
+      ""
     ],
     [
       17,
       "broad beans",
       "fava beans",
-      []
+      [
+        "fava beans"
+      ],
+      "",
+      ""
     ],
     [
       18,
       "butter beans",
       "lima beans",
-      []
+      [
+        "lima beans"
+      ],
+      "",
+      ""
     ],
     [
       19,
       "caster sugar",
       "superfine sugar",
-      []
+      [
+        "superfine sugar"
+      ],
+      "",
+      ""
     ],
     [
       20,
       "cavolo nero",
       "lacinato kale",
-      []
+      [
+        "lacinato kale"
+      ],
+      "",
+      ""
     ],
     [
       21,
       "celeriac",
       "celery root",
-      []
+      [
+        "celery root"
+      ],
+      "",
+      ""
     ],
     [
       22,
       "chestnut mushroom",
       "cremini mushroom",
-      []
+      [
+        "cremini mushroom"
+      ],
+      "",
+      ""
     ],
     [
       23,
       "chickpeas",
       "garbanzo beans",
-      []
+      [
+        "garbanzo beans"
+      ],
+      "",
+      ""
     ],
     [
       24,
       "Chinese leaf",
       "Napa cabbage",
-      []
+      [
+        "Napa cabbage"
+      ],
+      "",
+      ""
     ],
     [
       25,
       "chips",
       "French fries",
       [
+        "French fries",
         "chocolate chips",
         "tortilla chips",
         "corn chips",
         "butterscotch chips"
-      ]
+      ],
+      "",
+      ""
     ],
     [
       26,
       "chopped tomatoes",
       "canned diced tomatoes",
-      []
+      [
+        "canned diced tomatoes"
+      ],
+      "",
+      ""
     ],
     [
       27,
       "clingfilm",
       "plastic wrap",
-      []
+      [
+        "plastic wrap"
+      ],
+      "",
+      ""
     ],
     [
       28,
       "coriander",
       "cilantro",
       [
+        "cilantro",
         "coriander seed",
         "coriander seeds",
         "ground coriander",
         "coriander powder"
-      ]
+      ],
+      "",
+      ""
     ],
     [
       29,
       "cornflour",
       "cornstarch",
-      []
+      [
+        "cornstarch"
+      ],
+      "",
+      ""
     ],
     [
       30,
       "courgette",
       "zucchini",
-      []
+      [
+        "zucchini"
+      ],
+      "",
+      ""
     ],
     [
       31,
       "courgettes",
       "zucchinis",
-      []
+      [
+        "zucchinis"
+      ],
+      "",
+      ""
     ],
     [
       32,
       "single cream",
       "half-and-half",
-      []
+      [
+        "half-and-half"
+      ],
+      "",
+      ""
     ],
     [
       33,
       "double cream",
       "heavy cream",
-      []
+      [
+        "heavy cream"
+      ],
+      "",
+      ""
     ],
     [
       34,
       "crisps",
       "potato chips",
-      []
+      [
+        "potato chips"
+      ],
+      "",
+      ""
     ],
     [
       35,
       "Demerara sugar",
       "raw sugar",
-      []
+      [
+        "raw sugar"
+      ],
+      "",
+      ""
     ],
     [
       36,
       "desiccated coconut",
       "shredded unsweetened coconut",
-      []
+      [
+        "shredded unsweetened coconut"
+      ],
+      "",
+      ""
     ],
     [
       37,
       "digestive biscuits",
       "Graham crackers",
-      []
+      [
+        "Graham crackers"
+      ],
+      "",
+      ""
     ],
     [
       38,
       "medium eggs",
       "large eggs",
-      []
+      [
+        "eggs"
+      ],
+      "",
+      ""
     ],
     [
       39,
       "filo pastry",
       "phyllo pastry",
-      []
+      [
+        "phyllo pastry"
+      ],
+      "",
+      ""
     ],
     [
       40,
       "fish fingers",
       "fish sticks",
-      []
+      [
+        "fish sticks"
+      ],
+      "",
+      ""
     ],
     [
       41,
       "flat-leaf parsley",
       "Italian parsley",
-      []
+      [
+        "Italian parsley"
+      ],
+      "",
+      ""
     ],
     [
       42,
       "forced rhubarb",
       "hothouse rhubarb",
-      []
+      [
+        "hothouse rhubarb"
+      ],
+      "",
+      ""
     ],
     [
       43,
       "glace cherries",
       "candied cherries",
-      []
+      [
+        "candied cherries"
+      ],
+      "",
+      ""
     ],
     [
       44,
       "gooseberries",
       "berries",
-      []
+      [
+        "berries"
+      ],
+      "",
+      ""
     ],
     [
       45,
       "greengages",
       "plums",
-      []
+      [
+        "plums"
+      ],
+      "",
+      ""
     ],
     [
       46,
       "grill",
       "broil",
-      []
+      [
+        "broil"
+      ],
+      "",
+      ""
     ],
     [
       47,
       "ground almonds",
       "almond flour",
-      []
+      [
+        "almond flour"
+      ],
+      "",
+      ""
     ],
     [
       48,
       "groundnut oil",
       "peanut oil",
-      []
+      [
+        "peanut oil"
+      ],
+      "",
+      ""
     ],
     [
       49,
       "haricot beans",
       "navy beans",
-      []
+      [
+        "navy beans"
+      ],
+      "",
+      ""
     ],
     [
       50,
       "hispi cabbage",
       "pointed cabbage",
-      []
+      [
+        "pointed cabbage"
+      ],
+      "",
+      ""
     ],
     [
       51,
       "hob",
       "stovetop",
-      []
+      [
+        "stovetop"
+      ],
+      "",
+      ""
     ],
     [
       52,
       "ice lolly",
       "popsicle",
-      []
+      [
+        "popsicle"
+      ],
+      "",
+      ""
     ],
     [
       53,
       "icing sugar",
       "powdered sugar",
-      []
+      [
+        "powdered sugar"
+      ],
+      "",
+      ""
     ],
     [
       54,
       "jelly",
       "Jell-O",
-      []
+      [
+        "Jell-o"
+      ],
+      "",
+      ""
     ],
     [
       55,
       "Jersey Royals",
       "baby new potatoes",
-      []
+      [
+        "baby new potatoes"
+      ],
+      "",
+      ""
     ],
     [
       56,
       "jug",
       "pitcher",
-      []
+      [
+        "pitcher"
+      ],
+      "",
+      ""
     ],
     [
       57,
       "mangetout",
       "snow peas",
-      []
+      [
+        "snow peas"
+      ],
+      "",
+      ""
     ],
     [
       58,
       "milled chia seeds",
       "ground chia seeds",
-      []
+      [
+        "ground chia seeds"
+      ],
+      "",
+      ""
     ],
     [
       59,
       "mooli",
       "daikon radish",
-      []
+      [
+        "daikon radish"
+      ],
+      "",
+      ""
     ],
     [
       60,
       "muscovado sugar",
       "dark brown sugar",
-      []
+      [
+        "dark brown sugar"
+      ],
+      "",
+      ""
     ],
     [
       61,
       "onglet",
       "hanger steak",
-      []
+      [
+        "hanger steak"
+      ],
+      "",
+      ""
     ],
     [
       62,
       "pak choi",
       "bok choy",
-      []
+      [
+        "bok choy"
+      ],
+      "",
+      ""
     ],
     [
       63,
       "pepper",
       "black pepper",
       [
+        "black pepper",
         "bell pepper",
         "yellow pepper",
         "red pepper",
         "green pepper",
         "chilli pepper"
-      ]
+      ],
+      "",
+      ""
     ],
     [
       64,
       "plain flour",
       "all-purpose flour",
-      []
+      [
+        "all-purpose flour"
+      ],
+      "",
+      ""
     ],
     [
       65,
       "porridge oats",
       "oatmeal",
-      []
+      [
+        "oatmeal"
+      ],
+      "",
+      ""
     ],
     [
       66,
       "prawns",
       "shrimp",
-      []
+      [
+        "shrimp"
+      ],
+      "",
+      ""
     ],
     [
       67,
       "pudding",
       "dessert",
-      []
+      [
+        "dessert"
+      ],
+      "",
+      ""
     ],
     [
       68,
       "pudding rice",
       "short-grain rice",
-      []
+      [
+        "rice"
+      ],
+      "",
+      ""
     ],
     [
       69,
       "purple sprouting broccoli",
       "broccolini",
-      []
+      [
+        "broccolini"
+      ],
+      "",
+      ""
     ],
     [
       70,
       "rapeseed oil",
       "canola oil",
-      []
+      [
+        "canola oil"
+      ],
+      "",
+      ""
     ],
     [
       71,
       "rib roast",
       "prime rib",
-      []
+      [
+        "prime rib"
+      ],
+      "",
+      ""
     ],
     [
       72,
       "rocket",
       "arugula",
-      []
+      [
+        "arugula"
+      ],
+      "",
+      ""
     ],
     [
       73,
       "Scotch bonnet peppers",
       "habanero peppers",
-      []
+      [
+        "habanero peppers"
+      ],
+      "",
+      ""
     ],
     [
       74,
       "sea salt",
       "fine sea salt",
-      []
+      [
+        "fine sea salt"
+      ],
+      "",
+      ""
     ],
     [
       75,
       "self-raising flour",
       "self-rising flour",
-      []
+      [
+        "flour"
+      ],
+      "",
+      ""
     ],
     [
       76,
       "semi-skimmed milk",
       "low-fat milk",
-      []
+      [
+        "low-fat milk"
+      ],
+      "",
+      ""
     ],
     [
       77,
       "set honey",
       "creamed honey",
-      []
+      [
+        "creamed honey"
+      ],
+      "",
+      ""
     ],
     [
       78,
       "shin",
       "shank",
-      []
+      [
+        "shank"
+      ],
+      "",
+      ""
     ],
     [
       79,
       "shortcrust pastry",
       "pie crust",
-      []
+      [
+        "pie crust"
+      ],
+      "",
+      ""
     ],
     [
       80,
       "silverside",
       "bottom round",
-      []
+      [
+        "bottom round"
+      ],
+      "",
+      ""
     ],
     [
       81,
       "spring onion",
       "green onion",
-      []
+      [
+        "green onion"
+      ],
+      "",
+      ""
     ],
     [
       82,
       "strong white flour",
       "white bread flour",
-      []
+      [
+        "flour"
+      ],
+      "",
+      ""
     ],
     [
       83,
       "sultanas",
       "raisins",
-      []
+      [
+        "raisins"
+      ],
+      "",
+      ""
     ],
     [
       84,
       "swede",
       "rutabaga",
-      []
+      [
+        "rutabaga"
+      ],
+      "",
+      ""
     ],
     [
       85,
       "sweetcorn",
       "corn",
-      []
+      [
+        "corn"
+      ],
+      "",
+      ""
     ],
     [
       86,
       "Tenderstem broccoli",
       "broccolini",
-      []
+      [
+        "broccolini"
+      ],
+      "",
+      ""
     ],
     [
       87,
       "tomato puree",
       "tomato paste",
-      []
+      [
+        "tomato paste"
+      ],
+      "",
+      ""
     ],
     [
       88,
       "topside",
       "top round",
-      []
+      [
+        "top round"
+      ],
+      "",
+      ""
     ],
     [
       89,
       "treacle",
       "molasses",
-      []
+      [
+        "molasses"
+      ],
+      "",
+      ""
     ],
     [
       90,
       "wholemeal flour",
       "wholewheat flour",
-      []
+      [
+        "wholewheat flour"
+      ],
+      "",
+      ""
     ],
     [
       91,
       "dried active yeast",
       "active dry yeast",
-      []
+      [
+        "active dry yeast"
+      ],
+      "",
+      ""
     ],
     [
       92,
       "easy bake yeast",
       "instant yeast",
-      []
+      [
+        "instant yeast"
+      ],
+      "",
+      ""
     ],
     [
       93,
       "golden syrup",
       "light molasses or corn syrup",
-      []
+      [
+        "light molasses or corn syrup"
+      ],
+      "",
+      ""
     ],
     [
       94,
       "gammon",
       "cured ham",
-      []
+      [
+        "cured ham"
+      ],
+      "",
+      ""
     ],
     [
       95,
       "spring greens",
       "collard greens",
-      []
+      [
+        "collard greens"
+      ],
+      "",
+      ""
     ],
     [
       96,
       "gem lettuce",
       "Bibb lettuce",
-      []
+      [
+        "Bibb lettuce"
+      ],
+      "",
+      ""
     ],
     [
       97,
       "soured cream",
       "sour cream",
-      []
+      [
+        "sour cream"
+      ],
+      "",
+      ""
     ],
     [
       98,
       "fromage frais",
       "thick creamy yogurt",
-      []
+      [
+        "thick creamy yogurt"
+      ],
+      "",
+      ""
     ],
     [
       99,
       "suet",
       "beef fat",
-      []
+      [
+        "beef fat"
+      ],
+      "",
+      ""
     ],
     [
       100,
       "bangers",
       "sausages",
-      []
+      [
+        "sausages"
+      ],
+      "",
+      ""
     ],
     [
       101,
       "fairy cake",
       "cupcake",
-      []
+      [
+        "cupcake"
+      ],
+      "",
+      ""
     ],
     [
       102,
       "candy floss",
       "cotton candy",
-      []
+      [
+        "cotton candy"
+      ],
+      "",
+      ""
     ],
     [
       103,
       "greaseproof paper",
       "parchment paper",
-      []
+      [
+        "parchment paper"
+      ],
+      "",
+      ""
     ],
     [
       104,
       "tea towel",
       "dish towel",
-      []
+      [
+        "dish towel"
+      ],
+      "",
+      ""
     ],
     [
       105,
       "kitchen roll",
       "paper towels",
-      []
+      [
+        "paper towels"
+      ],
+      "",
+      ""
     ],
     [
       106,
       "washing-up liquid",
       "dish soap",
-      []
+      [
+        "dish soap"
+      ],
+      "",
+      ""
     ],
     [
       107,
       "gherkin",
       "pickle",
-      []
+      [
+        "pickle"
+      ],
+      "",
+      ""
     ],
     [
       108,
       "jacket potato",
       "baked potato",
-      []
+      [
+        "baked potato"
+      ],
+      "",
+      ""
     ],
     [
       109,
       "semolina",
       "farina",
-      []
+      [
+        "farina"
+      ],
+      "",
+      ""
     ],
     [
       110,
       "lemonade",
       "lemon-lime soda",
-      []
+      [
+        "lemon-lime soda"
+      ],
+      "",
+      ""
     ],
     [
       111,
       "bubble and squeak",
       "potato and cabbage hash",
-      []
+      [
+        "potato and cabbage hash"
+      ],
+      "",
+      ""
     ],
     [
       112,
       "saveloy",
       "frankfurter",
-      []
+      [
+        "frankfurter"
+      ],
+      "",
+      ""
     ],
     [
       113,
       "sponge",
-      "cake",
+      "frankfurter",
       [
+        "cake",
         "victoria sponge",
         "sponge cake",
         "bake sponge",
         "baked sponge",
         "sponge fingers"
-      ]
+      ],
+      "",
+      ""
     ]
   ]
 }"""

--- a/library/src/commonMain/kotlin/com/gu/recipe/terminology/TerminologyTable.kt
+++ b/library/src/commonMain/kotlin/com/gu/recipe/terminology/TerminologyTable.kt
@@ -2,7 +2,6 @@ package com.gu.recipe.terminology
 
 import kotlinx.serialization.*
 import kotlinx.serialization.json.*
-//import com.gu.recipe.generated.TerminologyFixture
 import com.gu.recipe.generated.internalTerminologyData
 
 @Serializable
@@ -14,7 +13,14 @@ data class TerminologySchema(
 
 
 @Serializable
-data class TerminologyEntry(val id: Int, val ukTerm: String, val usTerm: String, val block: List<String>)
+data class TerminologyEntry(
+    val id: Int,
+    val ukTerm: String,
+    val usTerm: String,
+    val block: List<String>,
+    val ukGuidance: String?,
+    val usGuidance: String?
+)
 
 /**
  * Converts UK terminology to US terminology.
@@ -96,33 +102,59 @@ class TerminologyTable(
     }
 
     /**
-     * Converts terminology in [text], returning null when [text] is null.
+     * Converts UK terminology to US terminology and provides extra notes about the conversion.
      *
-     * Blocked phrase ranges are cached per matched term for this invocation only. This avoids
-     * repeated scans for the same term in long strings while keeping singleton memory usage low.
+     * Each [TerminologyEntry.block] value is treated as a protected phrase span: a matched UK term is
+     * not replaced only when that exact match sits inside one of its blocked phrases. For example,
+     * `pepper` may be replaced generally, while the `pepper` in `red pepper` remains unchanged.
+     *
+     * The [convertTerm] function returns a [ConversionResult] containing the modified string and the
+     * last matched terminology entry, or null if no conversion occurred.
      */
-    internal fun convertTerm(text: String?): String? {
-        val source = text ?: return null
-        val regex = replacementRegex ?: return source
-        val blockedRangesByTerm = mutableMapOf<String, List<IntRange>>()
+    data class ConversionResult(
+        val replacedString: String,
+        val terminologyEntry: TerminologyEntry?
+    )
 
-        return regex.replace(source) { match ->
+    internal fun convertTerm(text: String?): ConversionResult? {
+        val source = text ?: return null
+        println("Converting text: $source")
+        val regex = replacementRegex ?: return null
+        println("Replacement regex: $regex")
+        val blockedRangesByTerm = mutableMapOf<String, List<IntRange>>()
+        println("Blocked ranges by term: $blockedRangesByTerm")
+
+        val replacements = mutableListOf<Pair<IntRange, String>>()
+        var lastMatchedEntry: TerminologyEntry? = null
+
+        regex.findAll(source).forEach { match ->
             val matchedTerm = match.value.lowercase()
+            println("Matched term: $matchedTerm")
             val replacementEntry = replacementMap[matchedTerm]
+            println("Replacement entry: $replacementEntry")
             if (replacementEntry != null) {
                 val blockedRanges = blockedRangesByTerm.getOrPut(matchedTerm) {
                     findBlockedRanges(source, replacementEntry)
                 }
                 if (!isBlocked(blockedRanges, match.range)) {
-                    replacementFor(match.value, replacementEntry)
-                } else {
-                    match.value
+                    val replacement = replacementFor(match.value, replacementEntry)
+                    println("Replaced term: $replacement")
+                    replacements.add(match.range to replacement)
+                    lastMatchedEntry = replacementEntry
                 }
-            } else {
-                match.value
             }
         }
+
+        // Apply replacements in reverse order to avoid invalidating ranges
+        var replacedString = source
+        for ((range, replacement) in replacements.asReversed()) {
+            replacedString = replacedString.replaceRange(range, replacement)
+        }
+
+        return ConversionResult(replacedString, lastMatchedEntry)
     }
+
+
 }
 
 fun loadInternalTerminologyTable(): Result<TerminologyTable> {
@@ -138,7 +170,9 @@ fun loadTerminologyTable(raw: String): Result<TerminologyTable> {
             val ukTerm = row[1].jsonPrimitive.content
             val usTerm = row[2].jsonPrimitive.content
             val block = row[3].jsonArray.map { it.jsonPrimitive.content }
-            ukTerm to TerminologyEntry(id = id, ukTerm = ukTerm, usTerm = usTerm, block = block)
+            val ukGuidance = row[4].jsonPrimitive.content
+            val usGuidance = row[5].jsonPrimitive.content
+            ukTerm to TerminologyEntry(id = id, ukTerm = ukTerm, usTerm = usTerm, block = block, ukGuidance = ukGuidance, usGuidance = usGuidance)
         }
 
         val table = TerminologyTable(terminologyMap)

--- a/library/src/commonTest/kotlin/com/gu/recipe/RenderRecipeTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/RenderRecipeTest.kt
@@ -577,8 +577,8 @@ class RenderRecipeTest {
             densityTable = DensityTable(preparedAt = "none", HashMap(), HashMap()),
             terminologyTable = com.gu.recipe.terminology.TerminologyTable(
                 terminologyMap = mapOf(
-                    "aubergine" to TerminologyEntry(id = 1, ukTerm = "aubergine", usTerm = "eggplant", block = emptyList()),
-                    "icing sugar" to TerminologyEntry(id = 2, ukTerm = "icing sugar",usTerm = "powdered sugar", block = emptyList())
+                    "aubergine" to TerminologyEntry(id = 1, ukTerm = "aubergine", usTerm = "eggplant", block = emptyList(), ukGuidance = null, usGuidance = null),
+                    "icing sugar" to TerminologyEntry(id = 2, ukTerm = "icing sugar",usTerm = "powdered sugar", block = emptyList(), ukGuidance = null, usGuidance = null)
                 )
             )
         )
@@ -621,7 +621,7 @@ class RenderRecipeTest {
         val session = RenderSession(
             densityTable = DensityTable(preparedAt = "none", HashMap(), HashMap()),
             terminologyTable = com.gu.recipe.terminology.TerminologyTable(
-                terminologyMap = mapOf("aubergine" to TerminologyEntry(id = 1, ukTerm = "aubergine", usTerm = "eggplant", block = emptyList()))
+                terminologyMap = mapOf("aubergine" to TerminologyEntry(id = 1, ukTerm = "aubergine", usTerm = "eggplant", block = emptyList(), ukGuidance = null, usGuidance = null))
             )
         )
         val recipe = RecipeV3(
@@ -653,7 +653,7 @@ class RenderRecipeTest {
         val session = RenderSession(
             densityTable = DensityTable(preparedAt = "none", HashMap(), HashMap()),
             terminologyTable = com.gu.recipe.terminology.TerminologyTable(
-                terminologyMap = mapOf("aubergine" to TerminologyEntry(id = 1, ukTerm = "aubergine", usTerm = "eggplant", block = emptyList()))
+                terminologyMap = mapOf("aubergine" to TerminologyEntry(id = 1, ukTerm = "aubergine", usTerm = "eggplant", block = emptyList(), ukGuidance = null, usGuidance = null))
             )
         )
         val recipe = RecipeV3(
@@ -685,7 +685,7 @@ class RenderRecipeTest {
         val session = RenderSession(
             densityTable = DensityTable(preparedAt = "none", HashMap(), HashMap()),
             terminologyTable = com.gu.recipe.terminology.TerminologyTable(
-                terminologyMap = mapOf("aubergine" to TerminologyEntry(id = 1, ukTerm = "aubergine", usTerm = "eggplant", block = emptyList()))
+                terminologyMap = mapOf("aubergine" to TerminologyEntry(id = 1, ukTerm = "aubergine", usTerm = "eggplant", block = emptyList(), ukGuidance = null, usGuidance = null))
             ),
             convertTerminologies = true
         )
@@ -698,7 +698,7 @@ class RenderRecipeTest {
         val session = RenderSession(
             densityTable = DensityTable(preparedAt = "none", HashMap(), HashMap()),
             terminologyTable = com.gu.recipe.terminology.TerminologyTable(
-                terminologyMap = mapOf("aubergine" to TerminologyEntry(id = 1, ukTerm = "aubergine", usTerm = "eggplant", block = emptyList()))
+                terminologyMap = mapOf("aubergine" to TerminologyEntry(id = 1, ukTerm = "aubergine", usTerm = "eggplant", block = emptyList(), ukGuidance = null, usGuidance = null))
             ),
             convertTerminologies = true
         )
@@ -711,7 +711,7 @@ class RenderRecipeTest {
         val session = RenderSession(
             densityTable = DensityTable(preparedAt = "none", HashMap(), HashMap()),
             terminologyTable = com.gu.recipe.terminology.TerminologyTable(
-                terminologyMap = mapOf("aubergine" to TerminologyEntry(id = 1, ukTerm = "aubergine", usTerm = "eggplant", block = emptyList()))
+                terminologyMap = mapOf("aubergine" to TerminologyEntry(id = 1, ukTerm = "aubergine", usTerm = "eggplant", block = emptyList(), ukGuidance = null, usGuidance = null))
             ),
             convertTerminologies = false
         )
@@ -724,7 +724,7 @@ class RenderRecipeTest {
         val session = RenderSession(
             densityTable = DensityTable(preparedAt = "none", HashMap(), HashMap()),
             terminologyTable = com.gu.recipe.terminology.TerminologyTable(
-                terminologyMap = mapOf("aubergine" to TerminologyEntry(id = 1, ukTerm = "aubergine", usTerm = "eggplant", block = emptyList()))
+                terminologyMap = mapOf("aubergine" to TerminologyEntry(id = 1, ukTerm = "aubergine", usTerm = "eggplant", block = emptyList(), ukGuidance = null, usGuidance = null))
             ),
             convertTerminologies = true
         )
@@ -737,7 +737,7 @@ class RenderRecipeTest {
         val session = RenderSession(
             densityTable = DensityTable(preparedAt = "none", HashMap(), HashMap()),
             terminologyTable = com.gu.recipe.terminology.TerminologyTable(
-                terminologyMap = mapOf("aubergine" to TerminologyEntry(id = 1, ukTerm = "aubergine", usTerm = "eggplant", block = emptyList()))
+                terminologyMap = mapOf("aubergine" to TerminologyEntry(id = 1, ukTerm = "aubergine", usTerm = "eggplant", block = emptyList(), ukGuidance = null, usGuidance = null))
             )
         )
 
@@ -751,8 +751,8 @@ class RenderRecipeTest {
             densityTable = DensityTable(preparedAt = "none", HashMap(), HashMap()),
             terminologyTable = com.gu.recipe.terminology.TerminologyTable(
                 terminologyMap = mapOf(
-                    "sugar" to TerminologyEntry(id = 1, ukTerm = "sugar", usTerm = "sweetener", block = emptyList()),
-                    "icing sugar" to TerminologyEntry(id = 2, ukTerm = "icing sugar", usTerm = "powdered sugar", block = emptyList())
+                    "sugar" to TerminologyEntry(id = 1, ukTerm = "sugar", usTerm = "sweetener", block = emptyList(), ukGuidance = null, usGuidance = null),
+                    "icing sugar" to TerminologyEntry(id = 2, ukTerm = "icing sugar", usTerm = "powdered sugar", block = emptyList(), ukGuidance = null, usGuidance = null)
                 )
             )
         )
@@ -765,7 +765,7 @@ class RenderRecipeTest {
         val session = RenderSession(
             densityTable = DensityTable(preparedAt = "none", HashMap(), HashMap()),
             terminologyTable = com.gu.recipe.terminology.TerminologyTable(
-                terminologyMap = mapOf("aubergine" to TerminologyEntry(id = 1, ukTerm = "aubergine", usTerm = "eggplant", block = emptyList()))
+                terminologyMap = mapOf("aubergine" to TerminologyEntry(id = 1, ukTerm = "aubergine", usTerm = "eggplant", block = emptyList(), ukGuidance = null, usGuidance = null))
             )
         )
         val scaledRecipe = RecipeV3(
@@ -791,7 +791,7 @@ class RenderRecipeTest {
         val session = RenderSession(
             densityTable = DensityTable(preparedAt = "none", HashMap(), HashMap()),
             terminologyTable = com.gu.recipe.terminology.TerminologyTable(
-                terminologyMap = mapOf("aubergine" to TerminologyEntry(id = 1, ukTerm = "aubergine", usTerm = "eggplant", block = emptyList()))
+                terminologyMap = mapOf("aubergine" to TerminologyEntry(id = 1, ukTerm = "aubergine", usTerm = "eggplant", block = emptyList(), ukGuidance = null, usGuidance = null))
             )
         )
         val scaledRecipe = RecipeV3(
@@ -819,6 +819,8 @@ class RenderRecipeTest {
             1.0f,
             MeasuringSystem.USCustomary
         )
+        println("-->>expectedRecipe: $expectedRecipe")
+        println("-->>result: $result")
         assertEquals(expectedRecipe, result)
     }
 
@@ -838,7 +840,9 @@ class RenderRecipeTest {
                             "bake sponge",
                             "baked sponge",
                             "sponge fingers"
-                        )
+                        ),
+                        ukGuidance = null,
+                        usGuidance = null
                     )
                 )
             )
@@ -861,4 +865,61 @@ class RenderRecipeTest {
         assertEquals("Put cake in a plate", rendered.instructions?.get(0)?.description)
         assertEquals("Get slice of Victoria sponge in a serving plate", rendered.instructions?.get(1)?.description)
     }
+
+    @Test
+    fun `renderRecipeForTerminology ALL converts every section with block list into consideration and notes as well`() {
+        val session = RenderSession(
+            densityTable = DensityTable(preparedAt = "none", HashMap(), HashMap()),
+            terminologyTable = com.gu.recipe.terminology.TerminologyTable(
+                terminologyMap = mapOf(
+                    "aubergine" to TerminologyEntry(
+                        id = 1,
+                        ukTerm = "aubergine",
+                        usTerm = "eggplant",
+                        block = listOf("eggplant"),
+                        ukGuidance = "This is uk guidance notes for aubergine",
+                        usGuidance = "This is us guidance notes for eggplant"
+                    ),
+                    "aubergines" to TerminologyEntry(
+                        id = 2,
+                        ukTerm = "aubergines",
+                        usTerm = "eggplants",
+                        block = listOf("eggplants"),
+                        ukGuidance = "This is uk guidance notes for aubergines",
+                        usGuidance = "This is us guidance notes for eggplants"
+                    )
+                )
+            )
+        )
+        val recipe = RecipeV3(
+            id = "test-recipe",
+            title = "Tamarind aubergine curry",
+            description = "The aubergine curry needs to be hot and tangy. We need green chillies and soaked tamarind.",
+            ingredients = listOf(
+                IngredientsList(
+                    ingredientsList = listOf(
+                        IngredientItem(
+                            text = "1 aubergine",
+                            template = "medium size aubergines"
+                        )
+                    )
+                )
+            ),
+            instructions = listOf(
+                Instruction(description = "Cut aubergines meanwhile soak tamarind in a water"),
+                Instruction(description = "Get portion of aubergine curry in a serving plate")
+            )
+        )
+
+        val rendered = session.renderRecipeForTerminology(recipe, TerminologySection.ALL)
+
+        assertEquals("Tamarind eggplant curry", rendered.title)
+        assertEquals("The eggplant curry needs to be hot and tangy. We need green chillies and soaked tamarind.", rendered.description)
+        assertEquals("1 eggplant", rendered.ingredients?.first()?.ingredientsList?.first()?.text)
+        assertEquals("medium size eggplants", rendered.ingredients?.first()?.ingredientsList?.first()?.template)
+        assertEquals("Cut eggplants meanwhile soak tamarind in a water", rendered.instructions?.get(0)?.description)
+        assertEquals("Get portion of eggplant curry in a serving plate", rendered.instructions?.get(1)?.description)
+    }
+
+
 }

--- a/library/src/commonTest/kotlin/com/gu/recipe/RenderRecipeTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/RenderRecipeTest.kt
@@ -917,9 +917,10 @@ class RenderRecipeTest {
         assertEquals("The eggplant curry needs to be hot and tangy. We need green chillies and soaked tamarind.", rendered.description)
         assertEquals("1 eggplant", rendered.ingredients?.first()?.ingredientsList?.first()?.text)
         assertEquals("medium size eggplants", rendered.ingredients?.first()?.ingredientsList?.first()?.template)
+        assertEquals("This is uk guidance notes for aubergine", rendered.ingredients?.first()?.ingredientsList?.first()?.ukGuidance)
+        assertEquals("This is us guidance notes for eggplant", rendered.ingredients?.first()?.ingredientsList?.first()?.usGuidance)
         assertEquals("Cut eggplants meanwhile soak tamarind in a water", rendered.instructions?.get(0)?.description)
-        assertEquals("Get portion of eggplant curry in a serving plate", rendered.instructions?.get(1)?.description)
-    }
+        assertEquals("Get portion of eggplant curry in a serving plate", rendered.instructions?.get(1)?.description)}
 
 
 }

--- a/library/src/commonTest/kotlin/com/gu/recipe/loader/DataLoaderTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/loader/DataLoaderTest.kt
@@ -15,8 +15,9 @@ class DataLoaderTest {
 """.trimIndent()
 
     private val validTerminologyJson = """
-    {"prepared_at":"2026-01-01T00:00:00","key":["id","ukTerm","usTerm","block"],"values":[[1,"aubergine","eggplant",[]],[2,"courgette","zucchini",[]]]}
+    {"prepared_at":"2026-07-23T14:33:07.361Z","key":["id","ukTerm","usTerm","block","ukGuidance","usGuidance"],"values":[[1,"aubergine","eggplant",["eggplant"],"Testing uk guidance notes for aubergine","Testing us guidance notes for eggplant"],[2,"courgette","zucchini",["zucchini"],"",""]]}
 """.trimIndent()
+
 
     private val invalidJson = "not valid json at all"
 

--- a/library/src/commonTest/kotlin/com/gu/recipe/terminology/TerminologyTableTest.kt
+++ b/library/src/commonTest/kotlin/com/gu/recipe/terminology/TerminologyTableTest.kt
@@ -13,14 +13,16 @@ class TerminologyTableTest {
                     id = 1,
                     ukTerm = "pepper",
                     usTerm = "black pepper",
-                    block = listOf(blockedPhrase)
+                    block = listOf(blockedPhrase),
+                    ukGuidance = "",
+                    usGuidance = ""
                 )
             )
         )
 
         assertEquals(
             blockedPhrase,
-            table.convertTerm(blockedPhrase)
+            table.convertTerm(blockedPhrase)!!.replacedString
         )
     }
 
@@ -32,14 +34,16 @@ class TerminologyTableTest {
                     id = 1,
                     ukTerm = "pepper",
                     usTerm = "black pepper",
-                    block = listOf("red pepper")
+                    block = listOf("red pepper"),
+                    ukGuidance = "",
+                    usGuidance = ""
                 )
             )
         )
 
         assertEquals(
             "tired black pepper",
-            table.convertTerm("tired pepper")
+            table.convertTerm("tired pepper")!!.replacedString
         )
     }
 
@@ -52,14 +56,16 @@ class TerminologyTableTest {
                     id = 1,
                     ukTerm = "sponge",
                     usTerm = "cake",
-                    block = listOf("victoria sponge", "sponge cake")
+                    block = listOf("victoria sponge", "sponge cake"),
+                    ukGuidance = "",
+                    usGuidance = ""
                 )
             )
         )
 
         assertEquals(
             "Victoria sponge with Cake and SPONGE CAKE.",
-            table.convertTerm("Victoria sponge with Sponge and SPONGE CAKE.")
+            table.convertTerm("Victoria sponge with Sponge and SPONGE CAKE.")!!.replacedString
         )
     }
 
@@ -71,14 +77,16 @@ class TerminologyTableTest {
                     id = 1,
                     ukTerm = "pepper",
                     usTerm = "black pepper",
-                    block = listOf("red pepper", "green pepper")
+                    block = listOf("red pepper", "green pepper"),
+                    ukGuidance = "",
+                    usGuidance = ""
                 )
             )
         )
 
         assertEquals(
             "black pepper, red pepper, black pepper, green pepper, black pepper.",
-            table.convertTerm("pepper, red pepper, pepper, green pepper, pepper.")
+            table.convertTerm("pepper, red pepper, pepper, green pepper, pepper.")!!.replacedString
         )
     }
 }


### PR DESCRIPTION
## What does this change?

As we progress in terminology, we are seeking to implement substitution in the feast application.
We intend to emphasise the guidance (notes) associated with specific terms that are challenging to convert and require greater attention compared to their related terms.

To assist users in gaining a comprehensive understanding of these terms, we are introduced guidance fields that will enable client developers to highlight the guidance notes to the associated terms.

This feature is for the ingredients section with new fields under the `ingredientItem` object.


## How to test

Run unit tests

----WIll add manually testing part here----

## How can we measure success?

Unit tests should pass

JSON schema should contain 2 new fields ukGuidance and usGuidance in the IngredientItem json object

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
